### PR TITLE
受講生情報の論理削除の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ config.yml
 
 # 一時ファイル
 *.log
+logs/
 *.tmp
 *.bak
 

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -1,6 +1,5 @@
 package raisetech.student.management.controller;
 
-import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
 import java.util.List;
@@ -47,7 +46,10 @@ public class StudentController {
 
     StudentRegistrationRequest request = new StudentRegistrationRequest();
     request.setStudent(student);
-    request.setCourses(studentCourses);
+    request.setDeleted(student.isDeleted());  // ← サーバーから正しく削除フラグを渡す
+
+    // 確認用ログ出力
+    System.out.println("Retrieved deleted flag: " + student.isDeleted());
 
     model.addAttribute("studentRegistrationRequest", request);
     return "editStudent";
@@ -61,10 +63,10 @@ public class StudentController {
     return "studentFindResults";
   }
 
-  // 生徒リストをサービスから取得　
+  // 生徒リストをサービスから取得（論理削除されていないもののみ）
   @GetMapping("/studentList")
   public String getStudentList(Model model) {
-    List<Student> students = service.searchStudentList();
+    List<Student> students = service.searchActiveStudents();
     List<StudentCourse> studentCourses = service.searchCourseList();
 
     model.addAttribute("studentList", converter.convertStudentDetails(students, studentCourses));
@@ -106,6 +108,8 @@ public class StudentController {
   public String updateStudent(
       @Validated @ModelAttribute("studentRegistrationRequest") StudentRegistrationRequest request,
       BindingResult result, Model model) {
+
+    System.out.println("Request deleted flag: " + request.isDeleted());  // 確認用のログ出力
 
     System.out.println("BindingResult has errors: " + result.hasErrors());
     System.out.println("Validation errors: " + result.getAllErrors());

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -131,14 +131,6 @@ public class StudentController {
     service.updateStudentWithCourses(request);
     return "redirect:/studentList";
   }
-  // 削除フラグだけを更新する
-  @PostMapping("/delete")
-  public String delete(@RequestParam String studentId, @RequestParam boolean deleted) {
-    Student student = service.findStudentById(studentId);
-    student.setDeleted(deleted);
-    service.delete(student);
-    return "redirect:/studentList";
-  }
 }
 
 

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -46,6 +46,7 @@ public class StudentController {
 
     StudentRegistrationRequest request = new StudentRegistrationRequest();
     request.setStudent(student);
+    request.setCourses(studentCourses);
     request.setDeleted(student.isDeleted());  // ← サーバーから正しく削除フラグを渡す
 
     // 確認用ログ出力
@@ -110,7 +111,7 @@ public class StudentController {
       BindingResult result, Model model) {
 
     System.out.println("Request deleted flag: " + request.isDeleted());  // 確認用のログ出力
-
+    System.out.println("Student deleted flag before update: " + request.getStudent().isDeleted());
     System.out.println("BindingResult has errors: " + result.hasErrors());
     System.out.println("Validation errors: " + result.getAllErrors());
 
@@ -126,6 +127,14 @@ public class StudentController {
 
     request.getStudent().setStudentId(studentId);
     service.updateStudentWithCourses(request);
+    return "redirect:/studentList";
+  }
+  // 削除フラグだけを更新する
+  @PostMapping("/toggleDeleteFlag")
+  public String toggleDeleteFlag(@RequestParam String studentId, @RequestParam boolean deleted) {
+    Student student = service.findStudentById(studentId);
+    student.setDeleted(deleted);
+    service.updateDeleteFlagOnly(student);
     return "redirect:/studentList";
   }
 }

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -1,5 +1,7 @@
 package raisetech.student.management.controller;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
 import java.util.List;
@@ -110,10 +112,10 @@ public class StudentController {
       @Validated @ModelAttribute("studentRegistrationRequest") StudentRegistrationRequest request,
       BindingResult result, Model model) {
 
-    System.out.println("Request deleted flag: " + request.isDeleted());  // 確認用のログ出力
-    System.out.println("Student deleted flag before update: " + request.getStudent().isDeleted());
-    System.out.println("BindingResult has errors: " + result.hasErrors());
-    System.out.println("Validation errors: " + result.getAllErrors());
+    Logger logger = LoggerFactory.getLogger(StudentController.class);
+
+    logger.debug("Request deleted flag: {}", request.isDeleted());
+    logger.debug("Student deleted flag before update: {}", request.getStudent().isDeleted());
 
     // studentId をリクエストから取得する
     String studentId = request.getStudent().getStudentId();
@@ -130,11 +132,11 @@ public class StudentController {
     return "redirect:/studentList";
   }
   // 削除フラグだけを更新する
-  @PostMapping("/toggleDeleteFlag")
-  public String toggleDeleteFlag(@RequestParam String studentId, @RequestParam boolean deleted) {
+  @PostMapping("/delete")
+  public String delete(@RequestParam String studentId, @RequestParam boolean deleted) {
     Student student = service.findStudentById(studentId);
     student.setDeleted(deleted);
-    service.updateDeleteFlagOnly(student);
+    service.delete(student);
     return "redirect:/studentList";
   }
 }

--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -32,10 +32,7 @@ public class Student {
   @NotNull(message = "メールアドレスは必須です。")
   @NotBlank(message = "メールアドレスを入力してください。")
   @Email(message = "メールアドレス形式で入力してください。")
-  @Pattern(
-      regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
-      message = "メールアドレス形式が不正です。"
-  )
+  @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "メールアドレス形式が不正です。")
   private String email;
   private String location;
   private int age;
@@ -45,16 +42,8 @@ public class Student {
   private String remarks = "";
   private LocalDateTime createdAt;
   private LocalDateTime deletedAt;
+  @Setter
   private boolean isDeleted; // 明示的な論理削除フラグを追加
-
-  /**
-   * 学生が論理削除されているかどうかを判定
-   *
-   * @return 削除されている場合は true, そうでなければ false
-   */
-  public boolean isDeleted() {
-    return isDeleted;
-  }
 
   /**
    * 学生を論理削除するメソッド

--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -42,7 +42,7 @@ public class Student {
   private String remarks = "";
   private LocalDateTime createdAt;
   private LocalDateTime deletedAt;
-  @Setter
+
   private boolean isDeleted; // 明示的な論理削除フラグを追加
 
   /**

--- a/src/main/java/raisetech/student/management/dto/StudentRegistrationRequest.java
+++ b/src/main/java/raisetech/student/management/dto/StudentRegistrationRequest.java
@@ -2,19 +2,23 @@ package raisetech.student.management.dto;
 
 import jakarta.validation.Valid;
 import java.util.List;
+
 import lombok.Getter;
 import lombok.Setter;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
 
-@Getter
 @Setter
+@Getter
 public class StudentRegistrationRequest {
 
-  @Valid
-  private Student student;  // これが重要：バリデーションの対象となるクラスに @Valid を付ける
+  @Valid // これが重要：バリデーションの対象となるクラスに @Valid を付ける
+  private Student student;
   private List<StudentCourse> courses;
   private String studentId;
+
+  private boolean deleted;  // フィールド名を isDeleted ではなく deleted に変更
+
 }
 
 

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -86,13 +86,6 @@ public interface StudentRepository {
   )
   void updateStudent(Student student);
 
-  /**
-   * updateStudent:削除フラグが立った受講生情報だけを更新するSQL
-   */
-
-  @Update("UPDATE students SET is_deleted = #{deleted} WHERE student_id = #{studentId}")
-  void deleteStudent(@Param("studentId") String studentId, @Param("deleted") boolean deleted);
-
 
   /**
    * deleteStudent:受講生情報をstudentIdで特定し削除するSQL

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -86,6 +86,12 @@ public interface StudentRepository {
   )
   void updateStudent(Student student);
 
+  /**
+   * updateStudent:削除フラグが立った受講生情報だけを更新するSQL
+   */
+
+  @Update("UPDATE students SET is_deleted = #{deleted} WHERE student_id = #{studentId}")
+  void updateStudentDeleteFlag(@Param("studentId") String studentId, @Param("deleted") boolean deleted);
 
   /**
    * deleteStudent:受講生情報をstudentIdで特定し削除するSQL

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -65,6 +65,13 @@ public interface StudentRepository {
   @Select("SELECT * FROM students WHERE REPLACE(furigana, '　', ' ') LIKE CONCAT('%', REPLACE(#{furigana}, '　', ' '), '%')")
   List<Student> findStudentsByFurigana(@Param("furigana") String furigana);
 
+  /**
+   * selectStudent: 論理削除されていない受講生の情報を検索するSQL。
+   */
+
+  @Select("SELECT * FROM students WHERE is_deleted = false")
+  List<Student> searchActiveStudents();
+
 
   /**
    * updateStudent:特定の受講生情報を更新するSQL
@@ -72,9 +79,13 @@ public interface StudentRepository {
 
   @Update(
       "UPDATE students SET full_name = #{fullName}, furigana = #{furigana}, nickname = #{nickname}, "
-          + "email = #{email}, location = #{location}, age = #{age}, gender = #{gender}, remarks = #{remarks} "
-          + "WHERE student_id = #{studentId}")
+          +
+          "email = #{email}, location = #{location}, age = #{age}, gender = #{gender}, remarks = #{remarks}, "
+          +
+          "is_deleted = #{deleted} WHERE student_id = #{studentId}"
+  )
   void updateStudent(Student student);
+
 
   /**
    * deleteStudent:受講生情報をstudentIdで特定し削除するSQL

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -91,7 +91,8 @@ public interface StudentRepository {
    */
 
   @Update("UPDATE students SET is_deleted = #{deleted} WHERE student_id = #{studentId}")
-  void updateStudentDeleteFlag(@Param("studentId") String studentId, @Param("deleted") boolean deleted);
+  void deleteStudent(@Param("studentId") String studentId, @Param("deleted") boolean deleted);
+
 
   /**
    * deleteStudent:受講生情報をstudentIdで特定し削除するSQL

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -2,6 +2,8 @@ package raisetech.student.management.service;
 
 import java.util.List;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,7 +79,20 @@ public class StudentService {
   @Transactional
   public void updateStudentWithCourses(StudentRegistrationRequest request) {
 
+    Logger logger = LoggerFactory.getLogger(StudentService.class);
+
+// ログ①: フォームから受け取った削除フラグ
+    logger.debug("request.isDeleted() = {}", request.isDeleted());
+
+// ログ②: セット前のStudentオブジェクトの削除フラグ
+    logger.debug("Before set: student.isDeleted = {}", request.getStudent().isDeleted());
+
+// 削除フラグを Student オブジェクトに反映
     request.getStudent().setDeleted(request.isDeleted());
+
+// ログ③: セット後のStudentオブジェクトの削除フラグ
+    logger.debug("After set: student.isDeleted = {}", request.getStudent().isDeleted());
+
 
     repository.updateStudent(request.getStudent());
 
@@ -89,10 +104,5 @@ public class StudentService {
         repository.insertCourse(course);
       }
     }
-  }
-
-  @Transactional
-  public void delete(Student student) {
-    repository.deleteStudent(student.getStudentId(), student.isDeleted());
   }
 }

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -73,25 +73,26 @@ public class StudentService {
     }
   }
 
+  // フル更新（フォームから courses を受け取ったときだけ呼ぶ）
   @Transactional
   public void updateStudentWithCourses(StudentRegistrationRequest request) {
 
-    // 論理削除の値を設定
     request.getStudent().setDeleted(request.isDeleted());
 
-    // まず既存のコースを削除
-    repository.deleteCoursesByStudentId(request.getStudent().getStudentId());
-
-    // その後、学生情報を更新
     repository.updateStudent(request.getStudent());
 
-    // コース情報の再登録
-    if (request.getCourses() != null) {
+    if (request.getCourses() != null && !request.getCourses().isEmpty()) {
+      repository.deleteCoursesByStudentId(request.getStudent().getStudentId());
       for (StudentCourse course : request.getCourses()) {
         course.setCourseId(UUID.randomUUID().toString());
         course.setStudentId(request.getStudent().getStudentId());
         repository.insertCourse(course);
       }
     }
+  }
+
+  @Transactional
+  public void updateDeleteFlagOnly(Student student) {
+    repository.updateStudentDeleteFlag(student.getStudentId(), student.isDeleted());
   }
 }

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -92,7 +92,7 @@ public class StudentService {
   }
 
   @Transactional
-  public void updateDeleteFlagOnly(Student student) {
-    repository.updateStudentDeleteFlag(student.getStudentId(), student.isDeleted());
+  public void delete(Student student) {
+    repository.deleteStudent(student.getStudentId(), student.isDeleted());
   }
 }

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -20,18 +20,20 @@ public class StudentService {
     this.repository = repository;
   }
 
-
   public List<Student> searchStudentList() {
     // 生徒のリストを取得
     return repository.search();
   }
 
+  // 論理削除されていない生徒を取得するメソッドを追加
+  public List<Student> searchActiveStudents() {
+    return repository.searchActiveStudents();
+  }
 
   public List<StudentCourse> searchCourseList() {
     // 全てのコースリストを取得
     return repository.findAllCourses();
   }
-
 
   public List<StudentCourse> searchCoursesByStudentId(String studentId) {
     // studentIdに紐付くコースリストを取得
@@ -42,7 +44,6 @@ public class StudentService {
     // studentIdで特定の生徒を探す
     return repository.findStudentById(studentId);
   }
-
 
   public List<Student> findStudentsByFurigana(String furigana) {
     // student.furiganaで特定の生徒を探す
@@ -74,6 +75,10 @@ public class StudentService {
 
   @Transactional
   public void updateStudentWithCourses(StudentRegistrationRequest request) {
+
+    // 論理削除の値を設定
+    request.getStudent().setDeleted(request.isDeleted());
+
     // まず既存のコースを削除
     repository.deleteCoursesByStudentId(request.getStudent().getStudentId());
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # application name
 spring.application.name=Student.management
 
-# datebase
+# database
 spring.datasource.url=jdbc:mysql://localhost:3306/StudentManagement?serverTimezone=Asia/Tokyo
 spring.datasource.username=root
 spring.datasource.password=MySQL@2M218e27
@@ -21,4 +21,20 @@ spring.datasource.hikari.maximumPoolSize=10
 
 # transaction (MyBatis)
 mybatis.configuration.defaultExecutorType=REUSE
+
+# Output logs to a file (relative path, creates logs/ in project root)
+logging.file.name=logs/app.log
+
+# Log format (optional: the default format is also acceptable)
+logging.pattern.file=%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+
+# Log level
+logging.level.raisetech.student.management.StudentService=DEBUG
+logging.level.raisetech.student.management.StudentController=DEBUG
+logging.level.root=INFO
+
+# Log rotation triggered at 10MB; retains up to 7 log files
+logging.file.max-size=10MB
+logging.file.max-history=7
+
 

--- a/src/main/resources/templates/editStudent.html
+++ b/src/main/resources/templates/editStudent.html
@@ -32,7 +32,7 @@
   <!-- 既存の form タグ内に追加 -->
   <!-- studentId を隠しフィールドとして送信 -->
   <!-- Thymeleaf のフィールドとして指定 -->
-  <input type="hidden" th:field="*{student.studentId}" />
+  <input type="hidden" th:field="*{student.studentId}"/>
 
   <!-- エラーメッセージ表示部分 -->
   <div th:if="${validationErrors != null}">
@@ -45,52 +45,59 @@
 
   <div>
     <label for="fullName">名前</label>
-    <input type="text" id="fullName" th:field="*{student.fullName}" />
+    <input type="text" id="fullName" th:field="*{student.fullName}"/>
   </div>
   <div>
     <label for="furigana">ふりがな</label>
-    <input type="text" id="furigana" th:field="*{student.furigana}" />
+    <input type="text" id="furigana" th:field="*{student.furigana}"/>
   </div>
   <div>
     <label for="nickname">ニックネーム</label>
-    <input type="text" id="nickname" th:field="*{student.nickname}" />
+    <input type="text" id="nickname" th:field="*{student.nickname}"/>
   </div>
   <div>
     <label for="email">メールアドレス</label>
-    <input type="email" id="email" th:field="*{student.email}" />
+    <input type="email" id="email" th:field="*{student.email}"/>
   </div>
   <div>
     <label for="location">お住まいの地域</label>
-    <input type="text" id="location" th:field="*{student.location}" />
+    <input type="text" id="location" th:field="*{student.location}"/>
   </div>
   <div>
     <label for="age">年齢</label>
-    <input type="number" id="age" th:field="*{student.age}" />
+    <input type="number" id="age" th:field="*{student.age}"/>
   </div>
   <div>
     <label for="gender">性別</label>
-    <input type="text" id="gender" th:field="*{student.gender}" />
+    <input type="text" id="gender" th:field="*{student.gender}"/>
   </div>
   <div>
     <label for="remarks">備考</label>
     <input type="text" id="remarks" th:field="*{student.remarks}"/>
   </div>
+  <div>
+    <label for="deleted">削除フラグ</label>
+    <input type="checkbox" id="deleted" th:field="*{deleted}"/>
+  </div>
 
   <h2>コース情報</h2>
   <div id="courseList">
     <div th:each="course, stat : ${studentRegistrationRequest.courses}">
-      <input type="hidden" th:name="|courses[${stat.index}].courseId|" th:value="${course.courseId}" />
+      <input type="hidden" th:name="|courses[${stat.index}].courseId|"
+             th:value="${course.courseId}"/>
       <div>
         <label>コース名</label>
-        <input type="text" th:name="|courses[${stat.index}].courseName|" th:value="${course.courseName}" />
+        <input type="text" th:name="|courses[${stat.index}].courseName|"
+               th:value="${course.courseName}"/>
       </div>
       <div>
         <label>開始日</label>
-        <input type="date" th:name="|courses[${stat.index}].startDate|" th:value="${course.startDate}" />
+        <input type="date" th:name="|courses[${stat.index}].startDate|"
+               th:value="${course.startDate}"/>
       </div>
       <div>
         <label>終了日</label>
-        <input type="date" th:name="|courses[${stat.index}].endDate|" th:value="${course.endDate}" />
+        <input type="date" th:name="|courses[${stat.index}].endDate|" th:value="${course.endDate}"/>
       </div>
     </div>
   </div>

--- a/src/main/resources/templates/editStudent.html
+++ b/src/main/resources/templates/editStudent.html
@@ -76,9 +76,15 @@
     <input type="text" id="remarks" th:field="*{student.remarks}"/>
   </div>
   <div>
-    <label for="deleted">削除フラグ</label>
-    <input type="checkbox" id="deleted" th:field="*{deleted}"/>
+    <!-- チェックなしのとき false を送信 -->
+    <input type="hidden" th:name="*{deleted}" value="false"/>
+
+    <!-- チェックされたら true を送信 -->
+    <label>
+      <input type="checkbox" th:field="*{deleted}" value="true"/> 削除フラグ
+    </label>
   </div>
+
 
   <h2>コース情報</h2>
   <div id="courseList">


### PR DESCRIPTION
受講生情報の論理削除の実装しました。
## 実行結果
### StudentListにアクセスし、論理削除対象者を確認

https://github.com/user-attachments/assets/4044c00d-bfce-47fa-9022-e752aaa94df7

### 論理削除を実行

https://github.com/user-attachments/assets/9b3a62e2-2451-4115-9f8d-9c764c72d099

### 論理削除を解除

https://github.com/user-attachments/assets/83cca554-c01f-43da-99a7-6c71c0a723db

