### PR TITLE
管理者用（認証付き）の物理削除API追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     //  Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    // Spring Security のスターター。認証・認可（ログイン制御やロールベースのアクセス制限）
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     //MySQLドライバ
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/raisetech/student/management/Application.java
+++ b/src/main/java/raisetech/student/management/Application.java
@@ -1,8 +1,10 @@
 package raisetech.student.management;
 
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+@MapperScan("raisetech.student.management.repository")
 @SpringBootApplication
 public class Application {
 

--- a/src/main/java/raisetech/student/management/ServletInitializer.java
+++ b/src/main/java/raisetech/student/management/ServletInitializer.java
@@ -3,8 +3,24 @@ package raisetech.student.management;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
+/**
+ * WARファイルとしてデプロイする際の初期化設定クラス。
+ * <p>
+ * このクラスは、アプリケーションを外部のサーブレットコンテナ（例：Tomcat）に
+ * デプロイするために必要な設定を提供します。
+ * 通常、Spring Boot アプリを自己実行（JAR）ではなく WAR 形式で配備する場合に使用されます。
+ */
 public class ServletInitializer extends SpringBootServletInitializer {
 
+  /**
+   * アプリケーションの起動設定をカスタマイズします。
+   * <p>
+   * 外部サーブレットコンテナ上でのデプロイ時に呼び出され、
+   * エントリポイントとなる {@code Application.class} を指定します。
+   *
+   * @param application SpringApplicationBuilder インスタンス
+   * @return カスタマイズされた SpringApplicationBuilder
+   */
   @Override
   protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
     return application.sources(Application.class);

--- a/src/main/java/raisetech/student/management/config/SecurityConfig.java
+++ b/src/main/java/raisetech/student/management/config/SecurityConfig.java
@@ -1,0 +1,66 @@
+package raisetech.student.management.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Spring Securityの設定クラス。
+ * <p>
+ * 本設定では、物理削除API（/api/admin/**）へのアクセスに認証を要求し、
+ * その他のAPIは認証不要としています。また、Basic認証とCSRF無効化を明示的に設定します。
+ */
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity // @PreAuthorizeなどのメソッドレベルセキュリティを有効化
+
+public class SecurityConfig {
+
+ /**
+  * アプリケーション全体のセキュリティフィルタチェーンを定義します。
+  *
+  * @param http HttpSecurityオブジェクト（Spring Securityの設定API）
+  * @return セキュリティフィルタチェーン
+  * @throws Exception セキュリティ設定中に例外が発生した場合
+  */
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .authorizeHttpRequests(auth -> auth
+            // /api/admin/** へのアクセス（物理削除API）には認証が必要
+            .requestMatchers("/api/admin/**").authenticated()
+            .anyRequest().permitAll() // 他はすべて許可
+        );
+
+    http
+        .httpBasic(basic -> {}) // 明示的にhttpBasicを有効化（空のラムダで設定）
+        .csrf(AbstractHttpConfigurer::disable); // 明示的にCSRF保護を無効化
+
+    return http.build();
+  }
+
+  /**
+   * 認証に使用するユーザー情報を提供するUserDetailsServiceを定義します。
+   * <p>
+   * 簡易的にインメモリで"admin"ユーザーを定義しています。
+   *
+   * @return InMemoryUserDetailsManagerのインスタンス
+   */
+  @Bean
+  public UserDetailsService userDetailsService() {
+    // 簡易的にインメモリでユーザーを定義
+    return new InMemoryUserDetailsManager(
+        User.withUsername("admin")
+            .password("{noop}password") // {noop}はパスワードエンコーディング無し
+            .roles("ADMIN")
+            .build()
+    );
+  }
+}

--- a/src/main/java/raisetech/student/management/config/typehandler/ByteArrayTypeHandler.java
+++ b/src/main/java/raisetech/student/management/config/typehandler/ByteArrayTypeHandler.java
@@ -1,0 +1,75 @@
+package raisetech.student.management.config.typehandler;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedJdbcTypes;
+import org.apache.ibatis.type.MappedTypes;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.CallableStatement;
+import java.sql.SQLException;
+
+/**
+ * MyBatis における {@code byte[]} 型と JDBC の BINARY 型とのマッピングを扱う TypeHandler。
+ * <p>
+ * UUID を BINARY(16) 型としてデータベースに格納・取得する際に使用されます。
+ * </p>
+ */
+@MappedJdbcTypes(JdbcType.BINARY)
+@MappedTypes(byte[].class)
+public class ByteArrayTypeHandler extends BaseTypeHandler<byte[]> {
+
+  /**
+   * {@code byte[]} 型のパラメータを {@link PreparedStatement} に設定します。
+   *
+   * @param ps         PreparedStatement オブジェクト
+   * @param i          パラメータのインデックス
+   * @param parameter  設定する byte 配列（通常は UUID のバイナリ形式）
+   * @param jdbcType   JDBC タイプ（この場合は BINARY）
+   * @throws SQLException JDBC 操作時の例外
+   */
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, byte[] parameter, JdbcType jdbcType) throws SQLException {
+    ps.setBytes(i, parameter);
+  }
+
+  /**
+   * {@link ResultSet} からカラム名を指定して byte 配列を取得します。
+   *
+   * @param rs         ResultSet オブジェクト
+   * @param columnName カラム名
+   * @return 取得された byte 配列、または NULL の場合は null
+   * @throws SQLException JDBC 操作時の例外
+   */
+  @Override
+  public byte[] getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    return rs.getBytes(columnName);
+  }
+
+  /**
+   * {@link ResultSet} からカラムのインデックスを指定して byte 配列を取得します。
+   *
+   * @param rs           ResultSet オブジェクト
+   * @param columnIndex  カラムのインデックス
+   * @return 取得された byte 配列、または NULL の場合は null
+   * @throws SQLException JDBC 操作時の例外
+   */
+  @Override
+  public byte[] getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    return rs.getBytes(columnIndex);
+  }
+
+  /**
+   * {@link CallableStatement} からカラムのインデックスを指定して byte 配列を取得します。
+   *
+   * @param cs           CallableStatement オブジェクト
+   * @param columnIndex  カラムのインデックス
+   * @return 取得された byte 配列、または NULL の場合は null
+   * @throws SQLException JDBC 操作時の例外
+   */
+  @Override
+  public byte[] getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    return cs.getBytes(columnIndex);
+  }
+}
+

--- a/src/main/java/raisetech/student/management/controller/admin/AdminStudentController.java
+++ b/src/main/java/raisetech/student/management/controller/admin/AdminStudentController.java
@@ -1,0 +1,36 @@
+package raisetech.student.management.controller.admin;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import raisetech.student.management.controller.converter.StudentConverter;
+import raisetech.student.management.service.StudentService;
+
+/**
+ * 管理者用の受講生物理削除APIコントローラー。
+ * <p>
+ * 管理者のみがアクセス可能で、物理削除を行います。
+ */
+@RestController
+@RequestMapping("/admin/students")
+@RequiredArgsConstructor
+public class AdminStudentController {
+
+  private final StudentService studentService;
+  private final StudentConverter converter;
+
+  /**
+   * 受講生を物理削除します（管理者専用）。
+   *
+   * @param studentId 物理削除対象の受講生ID（UUIDをBINARY(16)型で格納した16バイトの配列）
+   * @return 204 No Content
+   */
+  @DeleteMapping("/{studentId}")
+  @PreAuthorize("hasAuthority('ROLE_ADMIN')") // 管理者のみアクセス可能
+  public ResponseEntity<Void> forceDeleteStudent(@PathVariable String studentId) {
+    byte[] studentIdBytes = converter.decodeBase64(studentId);
+    studentService.forceDeleteStudent(studentIdBytes);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -1,30 +1,73 @@
 package raisetech.student.management.data;
 
 import java.time.LocalDateTime;
-import lombok.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
+/**
+ * 受講生の情報を保持するエンティティクラス。
+ * <p>
+ * このクラスはデータベースの「students」テーブルに対応し、
+ * 基本情報（氏名、ふりがな、メールアドレス等）に加えて
+ * 論理削除のためのフラグと削除日時も保持します。
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class Student {
-  private String studentId;
+
+  /** 学生ID（BINARY型、UUIDの16バイト配列） */
+  private byte[] studentId;
+
+  /** 氏名 */
   private String fullName;
+
+  /** ふりがな */
   private String furigana;
+
+  /** ニックネーム */
   private String nickname;
+
+  /** メールアドレス */
   private String email;
+
+  /** 居住地（都道府県など） */
   private String location;
+
+  /** 年齢 */
   private Integer age;
+
+  /** 性別 */
   private String gender;
+
+  /** 備考 */
   private String remarks;
+
+  /** 登録日時 */
   private LocalDateTime createdAt;
+
+  /** 論理削除された日時（削除されていない場合は null） */
   private LocalDateTime deletedAt;
+
+  /** 削除フラグ（true：削除済み、false：有効） */
   private Boolean deleted;
 
+  /**
+   * この受講生を論理削除します。
+   * <p>
+   * 削除フラグを true に設定し、削除日時を現在時刻に更新します。
+   */
   public void softDelete() {
     this.deleted = true;
     this.deletedAt = LocalDateTime.now();
   }
 
+  /**
+   * この受講生を復元します。
+   * <p>
+   * 削除フラグを false に設定し、削除日時を null にリセットします。
+   */
   public void restore() {
     this.deleted = false;
     this.deletedAt = null;

--- a/src/main/java/raisetech/student/management/data/StudentCourse.java
+++ b/src/main/java/raisetech/student/management/data/StudentCourse.java
@@ -2,17 +2,53 @@ package raisetech.student.management.data;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
+/**
+ * 受講生とコースの関連情報を保持するエンティティクラス。
+ * <p>
+ * 受講生がどのコースに所属しているか、受講期間などを管理します。
+ * データベースの student_courses テーブルに対応します。
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class StudentCourse {
-  private String courseId;
-  private String studentId;
+
+  /**
+   * コースID（BINARY型、Base64エンコード前の16バイト配列）。
+   * <p>
+   * UUIDをBINARY(16)で格納した形式。
+   */
+  private byte[] courseId;
+
+  /**
+   * 受講生ID（BINARY型、Base64エンコード前の16バイト配列）。
+   * <p>
+   * このコースに紐づく受講生のID。
+   */
+  private byte[] studentId;
+
+  /**
+   * コース名。
+   */
   private String courseName;
+
+  /**
+   * コースの開始日。
+   */
   private LocalDate startDate;
+
+  /**
+   * コースの終了日。
+   */
   private LocalDate endDate;
+
+  /**
+   * このエントリが作成された日時。
+   */
   private LocalDateTime createdAt;
 }
 

--- a/src/main/java/raisetech/student/management/domain/StudentDetail.java
+++ b/src/main/java/raisetech/student/management/domain/StudentDetail.java
@@ -6,13 +6,31 @@ import lombok.Setter;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
 
+/**
+ * 受講生の詳細情報（基本情報＋受講コース一覧）を表すドメインモデル。
+ * <p>
+ * クライアントやサービス層において、受講生と関連コースを一括で扱う際に使用します。
+ */
 @Getter
 @Setter
 public class StudentDetail {
 
+  /**
+   * 受講生の基本情報。
+   */
   private Student student;
+
+  /**
+   * 受講生に紐づくコース情報のリスト。
+   */
   private List<StudentCourse> studentCourse;
 
+  /**
+   * 受講生の詳細情報を生成するコンストラクタ。
+   *
+   * @param student        受講生の基本情報
+   * @param studentCourse  受講生が登録しているコース情報のリスト
+   */
   public StudentDetail(Student student, List<StudentCourse> studentCourse) {
     this.student = student;
     this.studentCourse = studentCourse;

--- a/src/main/java/raisetech/student/management/dto/StudentCourseDto.java
+++ b/src/main/java/raisetech/student/management/dto/StudentCourseDto.java
@@ -1,16 +1,41 @@
 package raisetech.student.management.dto;
 
-import lombok.*;
-
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 import java.time.LocalDate;
 
+/**
+ * 受講生が登録しているコース情報を表すデータ転送オブジェクト（DTO）。
+ * <p>
+ * クライアントとのリクエストおよびレスポンス時に使用されるクラスで、
+ * {@code StudentCourse} エンティティの必要な情報のみを提供します。
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class StudentCourseDto {
 
+  /**
+   * コースID（Base64エンコードされたUUID文字列）。
+   * <p>
+   * フロントエンドと通信する際に、BINARY型のUUIDをURLセーフな文字列として扱うために使用されます。
+   */
+  private String courseId;
+
+  /**
+   * コース名。
+   */
   private String courseName;
+
+  /**
+   * コースの開始日。
+   */
   private LocalDate startDate;
+
+  /**
+   * コースの終了日。
+   */
   private LocalDate endDate;
 }
 

--- a/src/main/java/raisetech/student/management/dto/StudentDetailDto.java
+++ b/src/main/java/raisetech/student/management/dto/StudentDetailDto.java
@@ -1,14 +1,29 @@
 package raisetech.student.management.dto;
 
-import lombok.*;
-
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 import java.util.List;
 
+/**
+ * 受講生の詳細情報（基本情報＋コース一覧）を表すデータ転送オブジェクト（DTO）。
+ * <p>
+ * APIのレスポンスやリクエストで、受講生の基本情報と関連するコース情報を
+ * 一括でやり取りするために使用されます。
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class StudentDetailDto {
+
+  /**
+   * 受講生の基本情報（ID、氏名、メールアドレスなど）。
+   */
   private StudentDto student;
+
+  /**
+   * 受講生が登録しているコース情報のリスト。
+   */
   private List<StudentCourseDto> courses;
 }
 

--- a/src/main/java/raisetech/student/management/dto/StudentDto.java
+++ b/src/main/java/raisetech/student/management/dto/StudentDto.java
@@ -1,38 +1,79 @@
 package raisetech.student.management.dto;
 
 import jakarta.validation.constraints.*;
-import lombok.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
+/**
+ * 受講生の基本情報を表すデータ転送オブジェクト（DTO）。
+ * <p>
+ * 登録・更新・検索時のリクエストおよびレスポンスで使用されるクラスであり、
+ * バリデーションアノテーションにより、リクエストデータの整合性を保証します。
+ */
 @Data
 @NoArgsConstructor // ← 引数なしのデフォルトコンストラクタも自動生成
 @AllArgsConstructor // ← 全フィールド引数のコンストラクタを自動生成
 public class StudentDto {
 
+  /**
+   * 受講生ID（Base64エンコードされたUUID文字列）。
+   * <p>
+   * 新規登録時は省略可能で、取得・更新時に使用されます。
+   */
   private String studentId;
 
+  /**
+   * 氏名（必須、最大100文字）。
+   */
   @NotBlank(message = "名前は必須です。")
   @Size(max = 100, message = "名前は100文字以内で入力してください。")
   private String fullName;
 
+  /**
+   * ふりがな（必須）。
+   */
   @NotBlank(message = "ふりがなは必須です。")
   private String furigana;
 
+  /**
+   * ニックネーム（必須）。
+   */
   @NotBlank(message = "ニックネームは必須です。")
   private String nickname;
 
+  /**
+   * メールアドレス（必須、形式チェックあり）。
+   */
   @NotBlank(message = "メールアドレスを入力してください。")
   @Email(message = "メールアドレス形式が不正です。")
   private String email;
 
+  /**
+   * 居住地（任意）。
+   */
   private String location;
 
+  /**
+   * 年齢（任意、0以上）。
+   */
   @Min(value = 0, message = "年齢は0以上で入力してください。")
   private Integer age;
 
+  /**
+   * 性別（必須）。
+   */
   @NotBlank(message = "性別は必須です。")
   private String gender;
 
+  /**
+   * 備考（任意）。
+   */
   private String remarks;
+
+  /**
+   * 論理削除フラグ。trueの場合、削除された状態を表します。
+   */
   private Boolean deleted;
 }
 

--- a/src/main/java/raisetech/student/management/dto/StudentRegistrationRequest.java
+++ b/src/main/java/raisetech/student/management/dto/StudentRegistrationRequest.java
@@ -1,20 +1,55 @@
 package raisetech.student.management.dto;
 
 import jakarta.validation.Valid;
-import lombok.*;
-
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 import java.util.List;
 
+/**
+ * 受講生の登録・更新リクエストに使用されるデータ転送オブジェクト（DTO）。
+ * <p>
+ * 受講生の基本情報と受講コース情報をまとめて送信するための構造であり、
+ * バリデーションアノテーションによりネストされたオブジェクトも検証されます。
+ */
 @Data
 @NoArgsConstructor // ← 引数なしのデフォルトコンストラクタも自動生成
 @AllArgsConstructor // ← 全フィールド引数のコンストラクタを自動生成
 public class StudentRegistrationRequest {
+
+  /**
+   * 登録または更新対象の受講生情報。
+   * <p>
+   * {@code @Valid} により、内部の各フィールドにもバリデーションが適用されます。
+   */
   @Valid
   private StudentDto student;
+
+  /**
+   * 登録または更新対象のコース情報一覧。
+   * <p>
+   * 空リストも許容されますが、各要素に対して {@code @Valid} による検証が行われます。
+   */
   @Valid
   private List<StudentCourseDto> courses;
+
+  /**
+   * 登録時に削除フラグを明示的に指定する場合に使用。
+   * <p>
+   * 通常は {@code false}（未削除）として登録されます。
+   */
   private boolean deleted;
+
+  private boolean appendCourses; // ← trueならコースを追加、falseなら置き換え
+
+  /*
+   このメソッドは不要 （@Dataがあるため、手動Getterは不要）
+   public boolean isAppendCourses() {
+   return appendCourses;
+   }
+  */
 }
+
 
 
 

--- a/src/main/java/raisetech/student/management/exception/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/student/management/exception/GlobalExceptionHandler.java
@@ -7,6 +7,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * アプリケーション全体で発生する例外を一元的に処理するハンドラー。
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
  */
 @ControllerAdvice
 public class GlobalExceptionHandler {
+  private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
   /**
    * バリデーション失敗時の例外処理。
@@ -47,5 +51,25 @@ public class GlobalExceptionHandler {
     responseBody.put("status", "error");
     responseBody.put("message", ex.getMessage());
     return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+  }
+
+  /**
+   * リクエストが不正（例：IDのデコード失敗など）なときの処理。
+   */
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException ex) {
+    Map<String, Object> responseBody = new HashMap<>();
+    responseBody.put("status", "error");
+    responseBody.put("message", "無効なリクエストです: " + ex.getMessage());
+    return new ResponseEntity<>(responseBody, HttpStatus.BAD_REQUEST);
+  }
+
+  /**
+   * その他の予期せぬ例外。
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<String> handleGeneralException(Exception ex) {
+    logger.error("Unhandled exception occurred", ex);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("予期しないエラーが発生しました。");
   }
 }

--- a/src/main/java/raisetech/student/management/repository/StudentCourseRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentCourseRepository.java
@@ -1,7 +1,8 @@
 package raisetech.student.management.repository;
 
 import java.util.List;
-import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import raisetech.student.management.data.StudentCourse;
 
 /**
@@ -11,39 +12,32 @@ import raisetech.student.management.data.StudentCourse;
 public interface StudentCourseRepository {
 
   /**
-   * 受講生のコース情報を登録します。
+   * 受講生の複数コース情報を一括で登録します。
    *
-   * @param course 登録するコース情報
+   * @param courses 登録するコースのリスト
    */
-  @Insert("""
-      INSERT INTO student_courses (course_id, student_id, course_name, start_date, end_date, created_at)
-      VALUES (UUID(), #{studentId}, #{courseName}, #{startDate}, #{endDate}, now())
-      """)
-  void insertCourse(StudentCourse course);
+  void insertCourses(@Param("list") List<StudentCourse> courses);
+
+  /**
+   * 存在しない場合に限り、新しいコースを追加します。
+   *
+   * @param course 追加対象のコース情報
+   */
+  void insertIfNotExists(StudentCourse course);
 
   /**
    * 指定された受講生IDに紐づくすべてのコース情報を削除します。
-   *
-   * @param studentId 対象の受講生ID
    */
-  @Delete("DELETE FROM student_courses WHERE student_id = #{studentId}")
-  void deleteCoursesByStudentId(String studentId);
+  void deleteCoursesByStudentId(@Param("studentId") byte[] studentId);
 
   /**
    * 指定された受講生IDに紐づくコース情報を取得します。
-   *
-   * @param studentId 受講生ID
-   * @return 該当するコース情報のリスト
    */
-  @Select("SELECT * FROM student_courses WHERE student_id = #{studentId}")
-  List<StudentCourse> findCoursesByStudentId(String studentId);
+  List<StudentCourse> findCoursesByStudentId(@Param("studentId") byte[] studentId);
 
   /**
    * すべての受講生コース情報を取得します。
-   *
-   * @return 全コース情報のリスト
    */
-  @Select("SELECT * FROM student_courses")
   List<StudentCourse> findAllCourses();
 }
 

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -29,7 +29,7 @@ public interface StudentRepository {
    * @param studentId 受講生ID
    * @return 該当する受講生情報（存在しない場合は null）
    */
-  Student findById(String studentId);
+  Student findById(@Param("studentId") byte[] studentId);
 
   /**
    * 新しい受講生情報を登録します。
@@ -45,13 +45,12 @@ public interface StudentRepository {
    */
   void updateStudent(Student student);
 
-
   /**
    * 受講生IDで該当する受講生情報を物理削除します。
    *
-   * @param studentId 削除対象の受講生ID
+   * @param studentId 物理削除対象の受講生ID
    */
-  void deleteById(String studentId);
+  void forceDeleteStudent(@Param("studentId") byte[] studentId);
 }
 
 

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -47,12 +47,32 @@ public interface StudentService {
   void partialUpdateStudent(Student student, List<StudentCourse> courses);
 
   /**
+   * 既存の受講生に対して、新しい受講コースを追加します。
+   * <p>
+   * このメソッドは、すでに存在する {@code student_id + course_name} の組み合わせを
+   * 保持したまま、新たなコース情報だけをデータベースに登録します。
+   * 既存のコースは削除されず、重複も防止されます。
+   *
+   * @param studentId 受講生の識別子（Base64デコード済みのBINARY型UUID）
+   * @param newCourses 追加対象の新しいコース情報のリスト
+   *                   {@code studentId} に紐づけられている必要があります
+   */
+  void appendCourses(byte[] studentId, List<StudentCourse> newCourses);
+
+  /**
+   * 受講生情報のみを更新します（コース情報は変更しません）。
+   *
+   * @param student 更新対象の受講生情報
+   */
+  void updateStudentInfoOnly(Student student);
+
+  /**
    * 受講生IDにより受講生情報を取得します。
    *
    * @param studentId 受講生ID
    * @return 受講生エンティティ
    */
-  Student findStudentById(String studentId);
+  Student findStudentById(byte[] studentId);
 
   /**
    * 受講生IDに紐づくコース情報を取得します。
@@ -60,7 +80,7 @@ public interface StudentService {
    * @param studentId 受講生ID
    * @return コースエンティティのリスト
    */
-  List<StudentCourse> searchCoursesByStudentId(String studentId);
+  List<StudentCourse> searchCoursesByStudentId(byte[] studentId);
 
   /**
    * 全てのコース情報を取得します。
@@ -74,21 +94,21 @@ public interface StudentService {
    *
    * @param studentId 受講生ID
    */
-  void softDeleteStudent(String studentId);
+  void softDeleteStudent(byte[] studentId);
 
   /**
    * 論理削除された受講生を復元します。
    *
    * @param studentId 受講生ID
    */
-  void restoreStudent(String studentId);
+  void restoreStudent(byte[] studentId);
 
   /**
-   * 受講生情報とそのコース情報を物理削除します。
+   * 受講生情報とそのコース情報を物理削除します（管理者専用）。
    *
-   * @param studentId 受講生ID
+   * @param studentId 削除対象の受講生ID
    */
-  void deleteStudentPhysically(String studentId);
+  void forceDeleteStudent(byte[] studentId);
 }
 
 

--- a/src/main/java/raisetech/student/management/util/UUIDUtil.java
+++ b/src/main/java/raisetech/student/management/util/UUIDUtil.java
@@ -1,0 +1,101 @@
+package raisetech.student.management.util;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.UUID;
+
+/**
+ * UUIDとBase64、byte[]相互の変換を提供するユーティリティクラス。
+ * <p>
+ * UUID（128bit）をバイナリ配列（byte[16]）やURLセーフなBase64形式に変換し、
+ * データベース（BINARY(16)）やWeb API（Base64文字列）との整合性を保つために使用されます。
+ */
+public class UUIDUtil {
+
+  // インスタンス化禁止
+  private UUIDUtil() {
+    throw new AssertionError("UUIDUtil should not be instantiated.");
+  }
+
+  /**
+   * UUIDからbyte[16]（バイナリ形式）に変換します。
+   *
+   * @param uuid UUIDオブジェクト
+   * @return UUIDのバイナリ表現（byte[16]）
+   */
+  public static byte[] fromUUID(UUID uuid) {
+    ByteBuffer buffer = ByteBuffer.allocate(16);
+    buffer.putLong(uuid.getMostSignificantBits());
+    buffer.putLong(uuid.getLeastSignificantBits());
+    return buffer.array();
+  }
+
+  /**
+   * byte[16]からUUIDオブジェクトに変換します。
+   *
+   * @param bytes UUIDのバイナリ表現（byte[16]）
+   * @return UUIDオブジェクト
+   * @throws IllegalArgumentException 長さが16バイトでない場合
+   */
+  public static UUID toUUID(byte[] bytes) {
+    if (bytes.length != 16) {
+      throw new IllegalArgumentException("UUIDバイナリは16バイトである必要があります。");
+    }
+    ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    long mostSigBits = buffer.getLong();
+    long leastSigBits = buffer.getLong();
+    return new UUID(mostSigBits, leastSigBits);
+  }
+
+  /**
+   * byte[] を URLセーフなBase64文字列にエンコードします（パディングなし）。
+   *
+   * @param bytes エンコード対象のバイナリデータ
+   * @return Base64エンコード文字列
+   */
+  public static String toBase64(byte[] bytes) {
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
+  /**
+   * URLセーフなBase64文字列から byte[] にデコードします。
+   *
+   * @param base64 デコード対象のBase64文字列
+   * @return バイナリデータ（通常はUUIDのbyte[16]）
+   */
+  public static byte[] fromBase64(String base64) {
+    return Base64.getUrlDecoder().decode(base64);
+  }
+
+  /**
+   * UUIDをBase64文字列に変換します。
+   *
+   * @param uuid UUIDオブジェクト
+   * @return Base64文字列（URLセーフ、パディングなし）
+   */
+  public static String toBase64(UUID uuid) {
+    return toBase64(fromUUID(uuid));
+  }
+
+  /**
+   * Base64文字列からUUIDを復元します。
+   *
+   * @param base64 Base64文字列（URLセーフ、パディングなし）
+   * @return UUIDオブジェクト
+   */
+  public static UUID fromBase64ToUUID(String base64) {
+    return toUUID(fromBase64(base64));
+  }
+
+  /**
+   * 動作確認用のmainメソッド。
+   * Base64文字列からUUID形式を表示します。
+   */
+  public static void main(String[] args) {
+    String base64Id = "GdgYbbFeRU6A70yPTVUN2A"; // 例: Webで受け取ったID
+    UUID uuid = fromBase64ToUUID(base64Id);
+    System.out.println("Base64: " + base64Id);
+    System.out.println("UUID形式: " + uuid.toString());
+    System.out.println("MySQL用: UNHEX(REPLACE('" + uuid.toString() + "', '-', ''))");
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,9 @@ spring.jpa.hibernate.ddl-auto=update
 mybatis.configuration.map-underscore-to-camel-case=true
 mybatis.configuration.log-impl=org.apache.ibatis.logging.stdout.StdOutImpl
 mybatis.mapper-locations=classpath:mappers/*.xml
+mybatis.type-aliases-package=raisetech.student.management.data
+mybatis.type-handlers-package=raisetech.student.management.config.typehandler
+
 
 # HikariCP
 spring.datasource.hikari.connectionTimeout=20000
@@ -30,8 +33,7 @@ logging.file.name=logs/app.log
 logging.pattern.file=%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
 
 # Log level
-logging.level.raisetech.student.management.StudentService=DEBUG
-logging.level.raisetech.student.management.StudentController=DEBUG
+logging.level.raisetech.student.management=DEBUG
 logging.level.root=INFO
 
 # Log rotation triggered at 10MB; retains up to 7 log files

--- a/src/main/resources/mappers/StudentCourseRepository.xml
+++ b/src/main/resources/mappers/StudentCourseRepository.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="raisetech.student.management.repository.StudentCourseRepository">
+
+  <!-- 登録 -->
+  <insert id="insertCourses" parameterType="java.util.List">
+    INSERT INTO student_courses (
+    course_id,
+    student_id,
+    course_name,
+    start_date,
+    end_date,
+    created_at
+    )
+    VALUES
+    <foreach collection="list" item="course" separator=",">
+    (
+    #{course.courseId, jdbcType=BINARY,
+    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
+    #{course.studentId, jdbcType=BINARY,
+    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
+    #{course.courseName},
+    #{course.startDate},
+    #{course.endDate},
+    NOW()
+    )
+    </foreach>
+  </insert>
+
+  <!-- 部分追加（登録） -->
+  <insert id="insertIfNotExists" parameterType="StudentCourse">
+    INSERT INTO student_courses (course_id, student_id, course_name, start_date, end_date, created_at)
+    SELECT
+    #{courseId, jdbcType=BINARY, typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
+    #{studentId, jdbcType=BINARY, typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
+    #{courseName},
+    #{startDate},
+    #{endDate},
+    NOW()
+    FROM DUAL
+    WHERE NOT EXISTS (
+    SELECT 1 FROM student_courses
+    WHERE student_id = #{studentId}
+    AND course_name = #{courseName}
+    )
+  </insert>
+
+  <!-- 削除 -->
+  <delete id="deleteCoursesByStudentId" parameterType="byte[]">
+    DELETE FROM student_courses WHERE student_id = #{studentId, jdbcType=BINARY,
+    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler}
+  </delete>
+
+  <!-- 特定の受講生のコースを取得 -->
+  <select id="findCoursesByStudentId" parameterType="byte[]" resultType="raisetech.student.management.data.StudentCourse">
+    SELECT * FROM student_courses WHERE student_id = #{studentId, jdbcType=BINARY,
+    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler}
+  </select>
+
+  <!-- 全件取得 -->
+  <select id="findAllCourses" resultType="raisetech.student.management.data.StudentCourse">
+    SELECT * FROM student_courses
+  </select>
+
+</mapper>
+

--- a/src/main/resources/mappers/StudentRepository.xml
+++ b/src/main/resources/mappers/StudentRepository.xml
@@ -37,21 +37,27 @@
       </when>
       <!-- includeDeleted = true && deletedOnly = false の場合はフィルタなし -->
     </choose>
+    ORDER BY created_at DESC
   </select>
 
   <!-- ID検索 -->
-  <select id="findById" resultMap="StudentResultMap">
-    SELECT * FROM students WHERE student_id = #{studentId}
+  <select id="findById" resultMap="StudentResultMap" parameterType="byte[]">
+    SELECT * FROM students WHERE student_id = #{studentId, jdbcType=BINARY,
+    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler}
   </select>
 
   <!-- 挿入 -->
-  <insert id="insertStudent">
-    INSERT INTO students (student_id, full_name, furigana, nickname, email, location, age, gender, remarks, created_at, is_deleted)
-    VALUES (#{studentId}, #{fullName}, #{furigana}, #{nickname}, #{email}, #{location}, #{age}, #{gender}, #{remarks}, now(), #{deleted})
+  <insert id="insertStudent" parameterType="raisetech.student.management.data.Student">
+    INSERT INTO students (student_id, full_name, furigana, nickname, email, location,
+    age, gender, remarks, created_at, is_deleted)
+    VALUES (#{studentId, jdbcType=BINARY,
+    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
+    #{fullName}, #{furigana}, #{nickname}, #{email}, #{location}, #{age}, #{gender}, #{remarks},
+    now(), #{deleted})
   </insert>
 
   <!-- 更新 -->
-  <update id="updateStudent">
+  <update id="updateStudent" parameterType="raisetech.student.management.data.Student">
     UPDATE students SET
     full_name = #{fullName},
     furigana = #{furigana},
@@ -63,42 +69,14 @@
     remarks = #{remarks},
     is_deleted = #{deleted},
     deleted_at = #{deletedAt}
-    WHERE student_id = #{studentId}
+    WHERE student_id = #{studentId, jdbcType=BINARY,
+    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler}
   </update>
 
-  <!-- 削除されていない学生 -->
-  <select id="searchActiveStudents" resultMap="StudentResultMap">
-    SELECT * FROM students WHERE is_deleted = false
-  </select>
-
-  <!-- 全学生 -->
-  <select id="findAllStudents" resultMap="StudentResultMap">
-    SELECT * FROM students
-  </select>
-
-  <!-- 削除済み学生 -->
-  <select id="findDeletedStudents" resultMap="StudentResultMap">
-    SELECT * FROM students WHERE is_deleted = true
-  </select>
-
-  <!-- ふりがな検索（削除されていない学生） -->
-  <select id="findByFurigana" resultMap="StudentResultMap">
-    SELECT * FROM students WHERE furigana LIKE CONCAT('%', #{furigana}, '%') AND is_deleted = false
-  </select>
-
-  <!-- ふりがな検索（削除状態問わず） -->
-  <select id="findByFuriganaIncludingDeleted" resultMap="StudentResultMap">
-    SELECT * FROM students WHERE furigana LIKE CONCAT('%', #{furigana}, '%')
-  </select>
-
-  <!-- ふりがな検索（削除済みのみ） -->
-  <select id="findDeletedStudentsByFurigana" resultMap="StudentResultMap">
-    SELECT * FROM students WHERE furigana LIKE CONCAT('%', #{furigana}, '%') AND is_deleted = true
-  </select>
-
   <!-- 物理削除 -->
-  <delete id="deleteById">
-    DELETE FROM students WHERE student_id = #{studentId}
+  <delete id="forceDeleteStudent" parameterType="byte[]">
+    DELETE FROM students WHERE student_id = #{studentId, jdbcType=BINARY,
+    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler}
   </delete>
 
 </mapper>

--- a/src/test/java/raisetech/student/management/ApplicationTests.java
+++ b/src/test/java/raisetech/student/management/ApplicationTests.java
@@ -3,11 +3,23 @@ package raisetech.student.management;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+/**
+ * Spring Boot アプリケーションの基本的な起動確認を行うテストクラス。
+ * <p>
+ * アプリケーションコンテキストが正しくロードされるかどうかを検証します。
+ * このテストが成功すれば、アプリケーションの構成や依存関係が正しく設定されていることが確認できます。
+ */
 @SpringBootTest
 class ApplicationTests {
 
+	/**
+	 * Spring アプリケーションコンテキストの読み込みが成功するかどうかをテストします。
+	 * <p>
+	 * 明示的なアサーションは行いませんが、コンテキストの初期化に失敗した場合は
+	 * テストが失敗します。
+	 */
 	@Test
 	void contextLoads() {
+		// コンテキストが正常に起動するかを確認するだけのテスト
 	}
-
 }

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -9,29 +9,60 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import raisetech.student.management.dto.StudentRegistrationRequest;
 import raisetech.student.management.service.StudentService;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.mockito.Mockito.*;
 
+/**
+ * {@link StudentController} のバリデーションエラーハンドリングを検証する単体テストクラス。
+ * <p>
+ * Spring MVC の {@code MockMvc} を使用して、フォーム送信に対するコントローラの動作を検証します。
+ */
 @ExtendWith(MockitoExtension.class)
 public class StudentControllerTest {
 
+  /**
+   * 疑似的なHTTPリクエスト・レスポンスを再現するテスト用オブジェクト。
+   */
   private MockMvc mockMvc;
 
+  /**
+   * モック化された {@link StudentService}。
+   * <p>
+   * コントローラの依存性として注入され、テスト対象外のサービスロジックを切り離します。
+   */
   @Mock
   private StudentService service;
 
+  /**
+   * テスト対象となる {@link StudentController}。
+   * <p>
+   * モック化された依存を持つ状態でテスト実行されます。
+   */
   @InjectMocks
   private StudentController controller;
 
+  /**
+   * 各テスト実行前に {@code MockMvc} を初期化します。
+   */
   @BeforeEach
   public void setup() {
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
   }
 
+  /**
+   * バリデーションエラーを含む受講生更新リクエストに対し、
+   * 適切なビュー名・ステータス・モデル属性が返されることを検証します。
+   * <p>
+   * 主な検証内容：
+   * <ul>
+   *   <li>バリデーション失敗時もステータスは200 OKで返ること</li>
+   *   <li>ビュー名が "editStudent" であること</li>
+   *   <li>エラーメッセージを含むモデル属性 "validationErrors" が存在すること</li>
+   * </ul>
+   *
+   * @throws Exception HTTP通信の模擬処理中に例外が発生した場合
+   */
   @Test
   public void testUpdateStudentWithValidationErrors() throws Exception {
 


### PR DESCRIPTION
機能追加：管理者用（認証あり）の物理削除APIを追加
リファクタ：UUIDをBase64にエンコードし、BINARY(16)型で保存する形式に変更
ドキュメント：全クラスにJavaDocコメント追加　etc...
※前回以上に課題以外の部分をいじり過ぎ、風呂敷を広げ過ぎてしまいました。
見苦しい部分が多々あるかと思いますが、ご確認いただけると幸いです。

## 動作確認
### 受講生一覧（削除済みは含まない）
https://github.com/user-attachments/assets/b55cd74c-e25d-480d-863b-41b6ef3539ca
### 受講生一覧（全件）
https://github.com/user-attachments/assets/ed473028-1bdd-491e-8dce-87164ad04f29
### 受講生一覧（論理削除のみ）
https://github.com/user-attachments/assets/6e895382-23da-4eeb-895b-9e9f13fffbd2
### 受講生一覧（論理削除者のみ抽出）
https://github.com/user-attachments/assets/d9e4f6b6-b910-4dac-a257-fc4c4f3d474b
### ふりがな検索（削除済み含む）在籍者を検索
https://github.com/user-attachments/assets/1efa27e7-36b3-4211-8c14-e9926d9b7f76
### ふりがな検索（削除済みは含まない）在籍者を検索
https://github.com/user-attachments/assets/a9dee9ed-ef93-410c-a9a6-32d0e8a31bcb
### ふりがな検索（削除済みは含まない）削除者を検索
https://github.com/user-attachments/assets/f1678635-03f4-4540-91d7-8604f220d190
### 単一受講生の詳細取得
https://github.com/user-attachments/assets/5f21aa47-16a3-49bc-a5b3-c7fbaed3ae78
### 受講生の新規登録
https://github.com/user-attachments/assets/d0b54b77-25bf-44d6-af4d-13417f3791f9
### 受講生情報の更新
https://github.com/user-attachments/assets/f8568caf-0b3d-4004-b3dd-b4a685a2fc16
### 受講生情報の一部更新　コース追加
https://github.com/user-attachments/assets/fcfa6469-8db0-4a94-b336-872a1a6f6627
### 受講生情報の論理削除
https://github.com/user-attachments/assets/24a3be9b-850e-40b9-8a2d-cadbd60354a9
### 論理削除された受講生情報を復元
https://github.com/user-attachments/assets/faf168e3-5fdd-477d-9725-96a6f367add4
### 受講生情報の完全削除
https://github.com/user-attachments/assets/5c09a37a-2da5-423e-8dbf-8013e6c44db7
### 論理削除エラー時
https://github.com/user-attachments/assets/93929cba-db22-4b4b-8a91-c0c615551ebf