### PR TITLE
［課題40］test: StudentServiceImplに各種ユースケースのテストを追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,11 +58,17 @@ dependencies {
 
     // JUnit テスト　ランチャー
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // JUnit（Jupiter）の本体ライブラリ
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+
+    testImplementation 'org.assertj:assertj-core:3.25.1'
+
 
     // Spring Boot Validation(Jakarta Validation API)
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     }
 
 tasks.named('test') {
+    // JUnitを使ってテストを実行するための設定
     useJUnitPlatform()
 }

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -86,7 +86,9 @@ public class StudentController {
     List<StudentCourse> courses = converter.toEntityList(request.getCourses(),
         studentIdBytes);
 
-    logger.debug("POST - Registering new student: {}", student.getFullName());
+    logger.debug("POST - Registering new student: {}, ID(Base64): {}",
+        student.getFullName(),
+    converter.encodeBase64(studentIdBytes));
     service.registerStudent(student, courses);
 
     StudentDetailDto responseDto = converter.toDetailDto(student, courses);

--- a/src/main/java/raisetech/student/management/dto/StudentRegistrationRequest.java
+++ b/src/main/java/raisetech/student/management/dto/StudentRegistrationRequest.java
@@ -3,6 +3,7 @@ package raisetech.student.management.dto;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
@@ -27,6 +28,7 @@ public class StudentRegistrationRequest {
    */
   @Schema(description = "受講生の基本情報", requiredMode = Schema.RequiredMode.REQUIRED)
   @Valid
+  @NotNull(message = "student は必須です")
   private StudentDto student;
 
   /**
@@ -39,6 +41,7 @@ public class StudentRegistrationRequest {
       description = "受講生の受講コース一覧")
   )
   @Valid
+  @NotNull(message = "courses は必須です")
   private List<StudentCourseDto> courses;
 
   /**

--- a/src/main/java/raisetech/student/management/exception/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/student/management/exception/GlobalExceptionHandler.java
@@ -26,7 +26,7 @@ import org.springframework.security.access.AccessDeniedException;
  * <p>
  * 各種カスタム例外に対応し、適切なHTTPステータスコードとエラーメッセージを返却します。
  */
-@RestControllerAdvice(basePackages = "raisetech.student.management.controller")
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);

--- a/src/main/java/raisetech/student/management/service/StudentServiceImpl.java
+++ b/src/main/java/raisetech/student/management/service/StudentServiceImpl.java
@@ -118,6 +118,9 @@ public class StudentServiceImpl implements StudentService {
   public List<StudentDetailDto> getStudentList(String furigana, boolean includeDeleted, boolean deletedOnly) {
     logger.debug("Searching students with furigana={}, includeDeleted={}, deletedOnly={}",
         furigana, includeDeleted, deletedOnly);
+    if (includeDeleted && deletedOnly) {
+      throw new IllegalArgumentException("includeDeletedとdeletedOnlyの両方をtrueにすることはできません");
+    }
     // 動的SQLにより1本化されたリポジトリメソッドを呼び出し
     List<Student> students = studentRepository.searchStudents(furigana, includeDeleted, deletedOnly); // 1本化！
     List<StudentCourse> courses = searchAllCourses();
@@ -227,7 +230,7 @@ public class StudentServiceImpl implements StudentService {
     String idForLog = converter.encodeBase64(studentId);
     // 存在確認
     if (studentRepository.findById(studentId) == null) {
-      throw new ResourceNotFoundException("学生ID " + idForLog + " が見つかりません。");
+      throw new ResourceNotFoundException("受講生ID " + idForLog + " が見つかりません。");
     }
     // 関連するコースも削除
     courseRepository.deleteCoursesByStudentId(studentId);
@@ -236,5 +239,6 @@ public class StudentServiceImpl implements StudentService {
     logger.info("物理削除完了 - studentId: {}", idForLog);
   }
 }
+
 
 

--- a/src/test/java/raisetech/student/management/service/StudentServiceImplTest.java
+++ b/src/test/java/raisetech/student/management/service/StudentServiceImplTest.java
@@ -1,0 +1,486 @@
+package raisetech.student.management.service;
+
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.ArgumentMatchers.anyList;
+
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import raisetech.student.management.controller.converter.StudentConverter;
+import raisetech.student.management.data.Student;
+import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.dto.StudentDetailDto;
+import raisetech.student.management.exception.ResourceNotFoundException;
+import raisetech.student.management.repository.StudentCourseRepository;
+import raisetech.student.management.repository.StudentRepository;
+
+@ExtendWith(MockitoExtension.class)
+class StudentServiceImplTest {
+
+  @Mock
+  private StudentRepository studentRepository;
+
+  @Mock
+  private StudentCourseRepository courseRepository;
+
+  @Mock
+  private StudentConverter converter;
+
+  @InjectMocks
+  private StudentServiceImpl service;
+
+  private static final String BASE64_ID = "3Jz8kUv2Rgq7Y+DnX3+aRQ==";
+
+  private byte[] studentId;
+  private Student student;
+  private StudentServiceImpl spyService;
+
+  // 各種テスト共通オブジェクトを準備
+  @BeforeEach
+  void setUp() {
+    studentId = Base64.getDecoder().decode(BASE64_ID);
+
+    student = new Student();
+    student.setStudentId(studentId);
+    student.setFullName("テスト　花子");
+    student.setEmail("test@example.com");
+    student.setAge(30);
+    spyService = Mockito.spy(service);
+
+    // コースを1件追加してcoursesを初期化
+    StudentCourse course = new StudentCourse();
+    course.setStudentId(studentId);
+    course.setCourseId(new byte[16]);  // 任意のダミーUUID（16バイト）
+
+  }
+
+  @Test
+  void 受講生登録時_コースが空ならコースは登録されないこと() {
+    // コースが空のケースにする
+    List<StudentCourse> emptyCourses = List.of();
+    // 実行
+    service.registerStudent(student, emptyCourses);
+
+    // 検証
+    // insertStudent() が1回呼ばれているかどうか？
+    verify(studentRepository, times(1)).insertStudent(student);
+    // insertCourses() は一度も呼ばれなかったかどうか？
+    verify(courseRepository, never()).insertCourses(anyList());
+  }
+
+  @Test
+  void updateStudent_受講生情報更新時_既存コースが削除され_新規コースが登録されること() {
+
+    // updateStudent用のオブジェクトを準備
+    StudentCourse course = new StudentCourse();
+    course.setStudentId(student.getStudentId());
+    course.setCourseId(Base64.getDecoder().decode("aGVsbG8tY291cnNlLWlk")); // 仮のCourse ID
+
+    List<StudentCourse> courses = List.of(course);
+
+    // 実行
+    service.updateStudent(student, courses);
+
+    // 検証 メソッドの呼び出しが順序通り行えているか？
+    InOrder inOrder = inOrder(studentRepository, courseRepository);
+    //studentRepository.updateStudent(student)メソッドが呼び出されているかどうか？
+    inOrder.verify(studentRepository).updateStudent(student);
+    // studentId に紐づく受講コースを 一括削除する処理が実行されたかどうか？
+    inOrder.verify(courseRepository).deleteCoursesByStudentId(student.getStudentId());
+    // 新たにcoursesをDBに登録する処理が呼び出されたかどうか？
+    inOrder.verify(courseRepository).insertCourses(courses);
+  }
+
+  @Test
+  void partialUpdateStudent_部分更新時_受講生情報が更新され_既存コース削除後_新規コースが登録されること() {
+
+    // partialUpdateStudent用のオブジェクトを準備
+    Student student = new Student();
+    student.setStudentId(Base64.getDecoder().decode("3Jz8kUv2Rgq7Y+DnX3+aRQ=="));
+    student.setFullName("検証 太郎");
+
+    List<StudentCourse> courses = List.of(new StudentCourse());
+
+    // 実行
+    service.partialUpdateStudent(student, courses);
+
+    // 検証
+    InOrder inOrder = inOrder(studentRepository, courseRepository);
+    //studentRepository.updateStudent(student)メソッドが呼び出されているかどうか？
+    inOrder.verify(studentRepository).updateStudent(student);
+    // studentId に紐づく受講コースを 一括削除する処理が実行されたかどうか？
+    inOrder.verify(courseRepository).deleteCoursesByStudentId(student.getStudentId());
+    inOrder.verify(courseRepository).insertCourses(courses);
+  }
+
+  @Test
+  void appendCourses_既に存在するコースにはinsertされないこと() {
+
+    // appendCourses用のオブジェクトを準備
+    StudentCourse course = new StudentCourse();
+    course.setStudentId(student.getStudentId());
+    course.setCourseId(new byte[16]);
+
+    List<StudentCourse> newCourses = List.of(course);
+
+    // 実行
+    service.appendCourses(student.getStudentId(), newCourses);
+
+    // insertIfNotExists が正しく呼ばれているか?
+    verify(courseRepository).insertIfNotExists(course);
+    // コースが複数ある場合は、すべて処理されているか?
+    verify(courseRepository, times(newCourses.size())).insertIfNotExists(any());
+  }
+
+  @Test
+  void updateStudentInfoOnlyが呼び出されると_リポジトリに委譲されること() {
+
+    // 準備
+    Student student = new Student();
+    student.setStudentId(new byte[16]);
+    student.setFullName("検証　テスト");
+
+    // 実行
+    service.updateStudentInfoOnly(student);
+
+    // 検証：studentRepository.updateStudent(...) が呼ばれていること
+    verify(studentRepository).updateStudent(student);
+  }
+
+  @Test
+  void getStudentList_ふりがな検索_で関連メソッドが順に呼ばれ結果が返ること() {
+
+    // 準備
+    String furigana = "やまだ　たかし";
+    boolean includeDeleted = false;
+    boolean deletedOnly = false;
+
+    List<Student> mockStudents = List.of(new Student());
+    List<StudentCourse> mockCourses = List.of(new StudentCourse());
+    List<StudentDetailDto> expectedDtoList = List.of(new StudentDetailDto());
+
+    when(studentRepository.searchStudents(furigana, includeDeleted, deletedOnly))
+        .thenReturn(mockStudents);
+
+    // searchAllCourses() の戻り値を差し替え
+    doReturn(mockCourses).when(spyService).searchAllCourses();
+
+    when(converter.toDetailDtoList(mockStudents, mockCourses))
+        .thenReturn(expectedDtoList);
+
+    // 実行
+    List<StudentDetailDto> result = spyService.getStudentList(furigana, includeDeleted,
+        deletedOnly);
+
+    // 主張
+    assertThat(result).isEqualTo(expectedDtoList);
+
+    // 呼び出し検証（順序付き）
+    InOrder inOrder = inOrder(studentRepository, spyService, converter);
+    inOrder.verify(studentRepository).searchStudents(furigana, includeDeleted, deletedOnly);
+    inOrder.verify(spyService).searchAllCourses();
+    inOrder.verify(converter).toDetailDtoList(mockStudents, mockCourses);
+
+  }
+
+  @Test
+  void getStudentList_論理削除含めた検索_で関連メソッドが順に呼ばれ結果が返ること() {
+
+    // 準備
+    String furigana = "さとう　じろう";
+    boolean includeDeleted = true;
+    boolean deletedOnly = false;
+
+    List<Student> mockStudents = List.of(new Student());
+    List<StudentCourse> mockCourses = List.of(new StudentCourse());
+    List<StudentDetailDto> expectedDtoList = List.of(new StudentDetailDto());
+
+    when(studentRepository.searchStudents(furigana, includeDeleted, deletedOnly))
+        .thenReturn(mockStudents);
+
+    // searchAllCourses() の戻り値を差し替え
+    doReturn(mockCourses).when(spyService).searchAllCourses();
+
+    when(converter.toDetailDtoList(mockStudents, mockCourses))
+        .thenReturn(expectedDtoList);
+
+    // 実行
+    List<StudentDetailDto> result = spyService.getStudentList(furigana, includeDeleted,
+        deletedOnly);
+
+    // 主張
+    assertThat(result).isEqualTo(expectedDtoList);
+
+    // 呼び出し検証（順序付き）
+    InOrder inOrder = inOrder(studentRepository, spyService, converter);
+    inOrder.verify(studentRepository).searchStudents(furigana, includeDeleted, deletedOnly);
+    inOrder.verify(spyService).searchAllCourses();
+    inOrder.verify(converter).toDetailDtoList(mockStudents, mockCourses);
+
+  }
+
+  @Test
+  void getStudentList_論理削除のみ検索_で関連メソッドが順に呼ばれ結果が返ること() {
+
+    // 準備
+    String furigana = "たかぎ　あかね";
+    boolean includeDeleted = false;
+    boolean deletedOnly = true;
+
+    List<Student> mockStudents = List.of(new Student());
+    List<StudentCourse> mockCourses = List.of(new StudentCourse());
+    List<StudentDetailDto> expectedDtoList = List.of(new StudentDetailDto());
+
+    when(studentRepository.searchStudents(furigana, includeDeleted, deletedOnly))
+        .thenReturn(mockStudents);
+
+    // searchAllCourses() の戻り値を差し替え
+    doReturn(mockCourses).when(spyService).searchAllCourses();
+
+    when(converter.toDetailDtoList(mockStudents, mockCourses))
+        .thenReturn(expectedDtoList);
+
+    // 実行
+    List<StudentDetailDto> result = spyService.getStudentList(furigana, includeDeleted,
+        deletedOnly);
+
+    // 主張
+    assertThat(result).isEqualTo(expectedDtoList);
+
+    // 呼び出し検証（順序付き）
+    InOrder inOrder = inOrder(studentRepository, spyService, converter);
+    inOrder.verify(studentRepository).searchStudents(furigana, includeDeleted, deletedOnly);
+    inOrder.verify(spyService).searchAllCourses();
+    inOrder.verify(converter).toDetailDtoList(mockStudents, mockCourses);
+
+  }
+
+  @Test
+  void getStudentList_論理削除と削除のみ検索が同時指定された場合_例外がスローされる() {
+
+    // 準備
+    String furigana = "たかはし　あや";
+    boolean includeDeleted = true;
+    boolean deletedOnly = true;
+
+    // 実行
+    assertThatThrownBy(() -> spyService.getStudentList(furigana, includeDeleted, deletedOnly))
+        // 検証
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("includeDeletedとdeletedOnlyの両方をtrueにすることはできません");
+  }
+
+  @Test
+  void findStudentById_該当する受講生IDで検索した場合_受講生情報が取得できること() {
+
+    // 準備（モックの設定）
+    when(studentRepository.findById(studentId)).thenReturn(student);
+
+    // 実行
+    Student result = service.findStudentById(studentId);
+
+    // 検証
+    assertThat(result).isEqualTo(student);
+    verify(studentRepository).findById(studentId);
+
+  }
+
+  @Test
+  void findStudentById_存在しないIDを指定_ResourceNotFoundExceptionがスローされること() {
+
+    // 準備（モックの設定）
+    when(studentRepository.findById(studentId)).thenReturn(null);
+    when(converter.encodeBase64(studentId)).thenReturn(BASE64_ID);
+
+    // 実行
+    assertThatThrownBy(() -> service.findStudentById(studentId))
+        // 検証
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("受講生ID " + BASE64_ID + " が見つかりません。");
+
+  }
+
+  @Test
+  void searchCoursesByStudentId_受講生IDで検索_紐づくコース情報を取得できること() {
+
+    // 準備
+    StudentCourse course1 = new StudentCourse();
+    course1.setStudentId(studentId);
+    course1.setCourseId(Base64.getDecoder().decode("Y291cnNlLWlkMQ==")); // 仮のCourse ID 1
+
+    StudentCourse course2 = new StudentCourse();
+    course2.setStudentId(studentId);
+    course2.setCourseId(Base64.getDecoder().decode("Y291cnNlLWlkMg==")); // 仮のCourse ID 2
+
+    List<StudentCourse> expectedCourses = List.of(course1, course2);
+
+    // モックの設定：courseRepositoryがstudentIdで検索されたら、expectedCoursesを返す
+    when(courseRepository.findCoursesByStudentId(studentId)).thenReturn(expectedCourses);
+
+    // 実行
+    List<StudentCourse> actualCourses = service.searchCoursesByStudentId(studentId);
+
+    // 検証
+    assertThat(actualCourses).isEqualTo(expectedCourses);
+    verify(courseRepository).findCoursesByStudentId(studentId); // 呼び出されたかも検証
+
+  }
+
+  @Test
+  void searchAllCourses_コース情報を全件取得すること() {
+
+    // 準備
+    StudentCourse course1 = new StudentCourse();
+    course1.setCourseId(Base64.getDecoder().decode("Y291cnNlLWlkMw=="));
+    course1.setCourseName("Javaコース");
+
+    StudentCourse course2 = new StudentCourse();
+    course2.setCourseId(Base64.getDecoder().decode("Y291cnNlLWlkNA=="));
+    course2.setCourseName("AWSコース");
+
+    List<StudentCourse> mockCourses = List.of(course1, course2);
+
+    // モック設定
+    when(courseRepository.findAllCourses()).thenReturn(mockCourses);
+
+    // 実行
+    List<StudentCourse> result = service.searchAllCourses();
+
+    // 検証
+    assertThat(result).isEqualTo(mockCourses);
+    verify(courseRepository).findAllCourses(); // 呼び出しがされたかどうかの確認
+  }
+
+  @Test
+  void softDeleteStudent_対象受講生が存在しなければ例外メッセージが投げられること() {
+
+    // モックの設定
+    when(studentRepository.findById(studentId)).thenReturn(null);
+    when(converter.encodeBase64(studentId)).thenReturn(BASE64_ID);
+
+    // 実行
+    assertThatThrownBy(() -> spyService.softDeleteStudent(studentId))
+        // 検証
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("Student not found for ID: " + BASE64_ID);
+
+  }
+
+  @Test
+  void softDeleteStudent_論理削除されていなければ削除処理が実行されること() {
+
+    // 準備
+    Student student = mock(Student.class);
+
+    // モックの準備
+    when(studentRepository.findById(studentId)).thenReturn(student);
+    when(student.getDeleted()).thenReturn(false);
+
+    // 実行
+    service.softDeleteStudent(studentId);
+
+    // 検証
+    verify(student).softDelete();
+    verify(studentRepository).updateStudent(student);
+
+  }
+
+  @Test
+  void restoreStudent_該当の受講生がいなければ例外メッセージが投げられること() {
+
+    // モックの設定
+    when(studentRepository.findById(studentId)).thenReturn(null);
+    when(converter.encodeBase64(studentId)).thenReturn(BASE64_ID);
+
+    // 実行
+    Throwable thrown = catchThrowable(() -> service.restoreStudent(studentId));
+    // 検証
+    assertThat(thrown)
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("受講生ID " + BASE64_ID + " が見つかりません。");
+  }
+
+  @Test
+  void restoreStudent_論理削除されている受講生が存在すれば受講生情報を復元すること() {
+    Student student = mock(Student.class);
+
+    when(student.getDeleted()).thenReturn(true);
+    when(studentRepository.findById(studentId)).thenReturn(student);
+    when(converter.encodeBase64(studentId)).thenReturn(BASE64_ID);
+
+    service.restoreStudent(studentId);
+
+    verify(student).restore(); // restore() 呼び出しの検証（可能なら）
+    verify(studentRepository).updateStudent(student);
+  }
+
+  @Test
+  void restoreStudent_論理削除されていない場合は更新処理が行われないこと() {
+    Student student = mock(Student.class);
+
+    when(student.getDeleted()).thenReturn(false);
+    when(studentRepository.findById(studentId)).thenReturn(student);
+    when(converter.encodeBase64(studentId)).thenReturn(BASE64_ID);
+
+    service.restoreStudent(studentId);
+
+    verify(studentRepository, never()).updateStudent(any());
+  }
+
+  @Test
+  void forceDeleteStudent_該当の受講生が存在しない時は例外がスローされること() {
+    // モックの設定
+    when(studentRepository.findById(studentId)).thenReturn(null);
+    when(converter.encodeBase64(studentId)).thenReturn(BASE64_ID);
+
+    // 実行＆検証
+    assertThatThrownBy(() -> service.forceDeleteStudent(studentId))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("受講生ID " + BASE64_ID + " が見つかりません。");
+  }
+
+  @Test
+  void forceDeleteStudent_受講生が存在する場合はコースと受講生情報が削除されること() {
+
+    // 準備
+    Student student = mock(Student.class);
+
+    // モックの準備
+    when(studentRepository.findById(studentId)).thenReturn(student);
+    when(converter.encodeBase64(studentId)).thenReturn(BASE64_ID);
+
+    // 実行
+    service.forceDeleteStudent(studentId);
+
+    // 検証：コース削除と物理削除が順序通り呼び出されたか
+    InOrder inOrder = inOrder(courseRepository, studentRepository);
+
+    inOrder.verify(courseRepository).deleteCoursesByStudentId(studentId);
+    inOrder.verify(studentRepository).forceDeleteStudent(studentId);
+    // 想定外の呼び出しがないか検証（すでに渡したmockを対象に）
+    inOrder.verifyNoMoreInteractions();
+
+  }
+}
+
+
+
+


### PR DESCRIPTION
## 実装内容
StudentServiceImplクラスの各種メソッド（ユースケース）にテストを追加しました

### 工夫した点・学んだこと
「メソッド名を分かりやすく」に注力しました。
メソッド数が思いのほか多かったので時間を要しました。条件分岐などがあった際には、条件ごとの確認が必要と分かりました。

### 動作確認
#### 受講生登録時にコースが空ならコースは登録されないこと

https://github.com/user-attachments/assets/325c27d6-d310-4fc4-b0a8-2834834c4983

#### 受講生情報更新時に既存コースが削除され、新規コースが登録されること

https://github.com/user-attachments/assets/d1db6b37-01ed-416d-878c-c6d0176ff228

#### 部分更新時に受講生情報が更新され、既存コース削除後に新規コースが登録されること

https://github.com/user-attachments/assets/75b4dec9-367a-40d8-bfa6-191a67fbadd7

#### 既に存在するコースにはinsertされないこと

https://github.com/user-attachments/assets/79123c55-e693-43c7-8652-f60941335981

#### updateStudentInfoOnlyが呼び出されると、リポジトリに委譲されること

https://github.com/user-attachments/assets/44fd56a1-23d5-44e9-a06c-eb9de90dbfad

#### ふりがな検索で関連メソッドが順に呼ばれ結果が返ること

https://github.com/user-attachments/assets/6b945d4d-9dc7-4db4-8ea2-9adfbdeaa43b

#### 論理削除含めた検索で関連メソッドが順に呼ばれ結果が返ること

https://github.com/user-attachments/assets/43c8a5f6-112d-4294-b277-573de8b8ae4b

#### 論理削除のみ検索で関連メソッドが順に呼ばれ結果が返ること

https://github.com/user-attachments/assets/924f15c6-929c-4068-ac64-e619231c45e2

#### 論理削除と削除のみ検索が同時指定された場合、例外がスローされること

https://github.com/user-attachments/assets/c90548a8-511b-4592-804f-5e88c06a4f84

#### 該当する受講生IDで検索した場合、受講生情報が取得できること

https://github.com/user-attachments/assets/940cdb46-2a82-405f-b836-b54d188e4aa7

#### 存在しないIDを指定すると、ResourceNotFoundExceptionがスローされること

https://github.com/user-attachments/assets/c34b8c1e-dd71-4e43-97bf-48c8f3010d65

#### 受講生IDで検索すると紐づくコース情報を取得できること

https://github.com/user-attachments/assets/15e76ee6-7217-45f9-ab29-e9d90698e7f3

#### コース情報を全件取得すること

https://github.com/user-attachments/assets/05e748cc-3ec0-4260-ba05-e2559d4cb581

#### softDeleteStudentで対象受講生が存在しなければ例外メッセージが投げられること

https://github.com/user-attachments/assets/1b9e86a2-ac30-4da9-a1c7-b7becc36d919

#### softDeleteStudentで論理削除されていなければ削除処理が実行されること

https://github.com/user-attachments/assets/6cea14bd-e98e-460c-9af7-613f279e8787

#### restoreStudentで該当の受講生がいなければ例外メッセージが投げられること

https://github.com/user-attachments/assets/e547a843-db28-4baf-9216-082a9a7663aa

#### restoreStudentで論理削除されている受講生が存在すれば受講生情報を復元すること

https://github.com/user-attachments/assets/950df66b-85e8-4239-9e7d-6ceb601e5db4

#### restoreStudentで論理削除されていない場合は更新処理が行われないこと

https://github.com/user-attachments/assets/7700ed48-e22a-4f78-83e1-d067085faa36

#### forceDeleteStudentで該当の受講生が存在しない時は例外がスローされること

https://github.com/user-attachments/assets/5be6b7f2-c18e-4854-8a02-c4c32b4b1a87

#### forceDeleteStudentで受講生が存在する場合はコースと受講生情報が削除されること

https://github.com/user-attachments/assets/68499400-e474-437e-a1ed-9f32d3128146
