### PR TITLE
Student/StudentCourseRepositoryおよびUUIDUtilのテスト実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,8 @@ dependencies {
     testImplementation "org.mockito:mockito-junit-jupiter:5.13.0"
     // MyBatis Test
     testImplementation "org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4"
+    // H2(InMemoryDB)
+    testImplementation "com.h2database:h2:2.3.232"
 
     // testImplementation 'org.mockito:mockito-core:5.12.0'
 

--- a/src/main/java/raisetech/student/management/config/typehandler/UUIDTypeHandler.java
+++ b/src/main/java/raisetech/student/management/config/typehandler/UUIDTypeHandler.java
@@ -1,0 +1,64 @@
+package raisetech.student.management.config.typehandler;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+import raisetech.student.management.util.UUIDUtil;
+
+/**
+ * MyBatis における {@link java.util.UUID} 型と JDBC の BINARY(16) 型とのマッピングを扱う TypeHandler。
+ *
+ * <p>UUID を BINARY(16) 型としてデータベースに格納・取得する際に使用されます。
+ */
+@MappedTypes(UUID.class)
+public class UUIDTypeHandler extends BaseTypeHandler<UUID> {
+
+  /**
+   * {@link UUID} 型のパラメータを {@link PreparedStatement} に BINARY(16) として設定します。
+   *
+   * @param ps        PreparedStatement オブジェクト
+   * @param i         パラメータのインデックス
+   * @param parameter 設定する UUID
+   * @param jdbcType  JDBC タイプ（この場合は BINARY）
+   * @throws SQLException JDBC 操作時の例外
+   */
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i,
+      UUID parameter, JdbcType jdbcType) throws SQLException {
+    byte[] bytes = UUIDUtil.toBytes(parameter);
+    ps.setBytes(i, bytes);
+  }
+
+  /**
+   * {@link ResultSet} からカラム名を指定して BINARY(16) を取得し UUID に変換します。
+   */
+  @Override
+  public UUID getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    byte[] bytes = rs.getBytes(columnName);
+    return UUIDUtil.fromBytes(bytes);
+  }
+
+  /**
+   * {@link ResultSet} からカラムのインデックスを指定して BINARY(16) を取得し UUID に変換します。
+   */
+  @Override
+  public UUID getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    byte[] bytes = rs.getBytes(columnIndex);
+    return UUIDUtil.fromBytes(bytes);
+  }
+
+  /**
+   * {@link CallableStatement} からカラムのインデックスを指定して BINARY(16) を取得し UUID に変換します。
+   */
+  @Override
+  public UUID getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    byte[] bytes = cs.getBytes(columnIndex);
+    return UUIDUtil.fromBytes(bytes);
+  }
+}
+

--- a/src/main/java/raisetech/student/management/controller/admin/AdminStudentController.java
+++ b/src/main/java/raisetech/student/management/controller/admin/AdminStudentController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -39,10 +40,10 @@ public class AdminStudentController {
    *
    * <p>処理の流れ:
    * <ul>
-   *   <li>パス変数 {@code studentId}（UUID 文字列表現）を
-   *   {@link StudentConverter#decodeUuidStringToBytesOrThrow(String)} でデコードして
+   *   <li>パス変数 {@code studentId}（UUID 文字列）を
+   *   {@link StudentConverter#decodeUuidStringOrThrow(String)} でデコードして
    *   UUID 由来の 16 バイト配列に変換する</li>
-   *   <li>デコード済みの ID を用いて {@link StudentService#forceDeleteStudent(byte[])} を呼び出し、
+   *   <li>デコード済みの ID を用いて {@link StudentService#forceDeleteStudent(UUID)} を呼び出し、
    *   該当レコードを物理削除する</li>
    * </ul>
    *
@@ -86,8 +87,8 @@ public class AdminStudentController {
   @DeleteMapping("/{studentId}")
   @PreAuthorize("hasAuthority('ROLE_ADMIN')") // 管理者のみアクセス可能
   public ResponseEntity<Void> forceDeleteStudent(@PathVariable String studentId) {
-    byte[] studentIdBytes = converter.decodeUuidStringToBytesOrThrow(studentId);
-    studentService.forceDeleteStudent(studentIdBytes);
+    UUID studentUuid = converter.decodeUuidStringOrThrow(studentId);
+    studentService.forceDeleteStudent(studentUuid);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -19,12 +19,12 @@ import lombok.NoArgsConstructor;
 public class Student {
 
   /**
-   * 学生ID（BINARY型、UUIDの16バイト配列）
+   * 受講生ID（UUID（DBではBINARY(16)として格納））
    */
   @Schema(
-      description = "学生ID（UUIDをBINARY形式で格納した16バイト配列）",
-      format = "byte",
-      example = "MTIzNDU2Nzg5MGFiY2RlZg==")
+      description = "受講生ID（DBではBINARY(16)で格納）",
+      format = "uuid",
+      example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
   private UUID studentId;
 
   /**

--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -1,8 +1,8 @@
 package raisetech.student.management.data;
 
-import java.time.LocalDateTime;
-
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -18,54 +18,78 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Student {
 
-  /** 学生ID（BINARY型、UUIDの16バイト配列） */
+  /**
+   * 学生ID（BINARY型、UUIDの16バイト配列）
+   */
   @Schema(
       description = "学生ID（UUIDをBINARY形式で格納した16バイト配列）",
       format = "byte",
       example = "MTIzNDU2Nzg5MGFiY2RlZg==")
-  private byte[] studentId;
+  private UUID studentId;
 
-  /** 氏名 */
+  /**
+   * 氏名
+   */
   @Schema(description = "氏名", example = "山田 太郎")
   private String fullName;
 
-  /** ふりがな */
+  /**
+   * ふりがな
+   */
   @Schema(description = "ふりがな", example = "やまだ たろう")
   private String furigana;
 
-  /** ニックネーム */
+  /**
+   * ニックネーム
+   */
   @Schema(description = "ニックネーム", example = "タロウ")
   private String nickname;
 
-  /** メールアドレス */
+  /**
+   * メールアドレス
+   */
   @Schema(description = "メールアドレス", example = "taro.yamada@example.com")
   private String email;
 
-  /** 居住地（都道府県など） */
+  /**
+   * 居住地（都道府県など）
+   */
   @Schema(description = "居住地（都道府県など）", example = "Osaka,韓国")
   private String location;
 
-  /** 年齢 */
+  /**
+   * 年齢
+   */
   @Schema(description = "年齢", example = "25")
   private Integer age;
 
-  /** 性別 */
+  /**
+   * 性別
+   */
   @Schema(description = "性別", example = "Male")
   private String gender;
 
-  /** 備考 */
+  /**
+   * 備考
+   */
   @Schema(description = "備考・自由記述欄", example = "メモや特記事項")
   private String remarks;
 
-  /** 登録日時 */
+  /**
+   * 登録日時
+   */
   @Schema(description = "登録日時", example = "2025-04-01 10:00:00")
   private LocalDateTime createdAt;
 
-  /** 論理削除された日時（削除されていない場合は null） */
+  /**
+   * 論理削除された日時（削除されていない場合は null）
+   */
   @Schema(description = "削除日時（論理削除時のみ値が入る）", example = "2025-06-01 12:30:00", nullable = true)
   private LocalDateTime deletedAt;
 
-  /** 削除フラグ（true：削除済み、false：有効） */
+  /**
+   * 削除フラグ（true：削除済み、false：有効）
+   */
   @Schema(description = "論理削除フラグ。trueの場合、削除された状態を表します。", example = "false")
   private Boolean deleted;
 

--- a/src/main/java/raisetech/student/management/data/StudentCourse.java
+++ b/src/main/java/raisetech/student/management/data/StudentCourse.java
@@ -3,6 +3,7 @@ package raisetech.student.management.data;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -26,7 +27,7 @@ public class StudentCourse {
   @Schema(
       description = "コースID（UUIDをBINARY形式で格納した16バイト配列）",
       format = "byte")
-  private byte[] courseId;
+  private UUID courseId;
 
   /**
    * 受講生ID（UUID を BINARY(16) として保持する 16 バイト配列）。
@@ -36,7 +37,7 @@ public class StudentCourse {
   @Schema(
       description = "受講生ID（UUIDをBINARY形式で格納した16バイト配列）",
       format = "byte")
-  private byte[] studentId;
+  private UUID studentId;
 
   /**
    * コース名。

--- a/src/main/java/raisetech/student/management/data/StudentCourse.java
+++ b/src/main/java/raisetech/student/management/data/StudentCourse.java
@@ -20,23 +20,28 @@ import lombok.NoArgsConstructor;
 public class StudentCourse {
 
   /**
-   * コースID（UUID を BINARY(16) として保持する 16 バイト配列）。
+   * コースID（UUID（DBではBINARY(16)として格納））。
    *
-   * <p>データベースでは BINARY(16) で格納され、API 層では UUID 文字列表現に変換して扱われます。
+   * <p>データベースでは BINARY(16) で格納され、アプリケーション内部では UUID型 として扱います。
+   * API（JSON）では UUIDは文字列形式 で送受信されます。
    */
   @Schema(
-      description = "コースID（UUIDをBINARY形式で格納した16バイト配列）",
-      format = "byte")
+      description = "コースID（DBではBINARY(16)で格納）",
+      format = "uuid",
+      example = "550e8400-e29b-41d4-a716-446655440000"
+  )
   private UUID courseId;
 
   /**
-   * 受講生ID（UUID を BINARY(16) として保持する 16 バイト配列）。
+   * 受講生ID（UUID（DBではBINARY(16)として格納））。
    *
    * <p>このコースに紐づく受講生のID。
    */
   @Schema(
-      description = "受講生ID（UUIDをBINARY形式で格納した16バイト配列）",
-      format = "byte")
+      description = "受講生ID（DBではBINARY(16)で格納）",
+      format = "uuid",
+      example = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+  )
   private UUID studentId;
 
   /**

--- a/src/main/java/raisetech/student/management/repository/StudentCourseRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentCourseRepository.java
@@ -1,13 +1,14 @@
 package raisetech.student.management.repository;
 
 import java.util.List;
-
+import java.util.UUID;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-
 import raisetech.student.management.data.StudentCourse;
 
-/** 受講生のコース情報に関するデータベース操作を行うMyBatisリポジトリ。 */
+/**
+ * 受講生のコース情報に関するデータベース操作を行うMyBatisリポジトリ。
+ */
 @Mapper
 public interface StudentCourseRepository {
 
@@ -25,12 +26,18 @@ public interface StudentCourseRepository {
    */
   void insertIfNotExists(StudentCourse course);
 
-  /** 指定された受講生IDに紐づくすべてのコース情報を削除します。 */
-  void deleteCoursesByStudentId(@Param("studentId") byte[] studentId);
+  /**
+   * 指定された受講生IDに紐づくすべてのコース情報を削除します。
+   */
+  void deleteCoursesByStudentId(@Param("studentId") UUID studentId);
 
-  /** 指定された受講生IDに紐づくコース情報を取得します。 */
-  List<StudentCourse> findCoursesByStudentId(@Param("studentId") byte[] studentId);
+  /**
+   * 指定された受講生IDに紐づくコース情報を取得します。
+   */
+  List<StudentCourse> findCoursesByStudentId(@Param("studentId") UUID studentId);
 
-  /** すべての受講生コース情報を取得します。 */
+  /**
+   * すべての受講生コース情報を取得します。
+   */
   List<StudentCourse> findAllCourses();
 }

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -1,6 +1,7 @@
 package raisetech.student.management.repository;
 
 import java.util.List;
+import java.util.UUID;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import raisetech.student.management.data.Student;
@@ -32,7 +33,7 @@ public interface StudentRepository {
    * @param studentId 受講生ID
    * @return 該当する受講生情報（存在しない場合は null）
    */
-  Student findById(@Param("studentId") byte[] studentId);
+  Student findById(@Param("studentId") UUID studentId);
 
   /**
    * 新しい受講生情報を登録します。
@@ -53,5 +54,5 @@ public interface StudentRepository {
    *
    * @param studentId 物理削除対象の受講生ID
    */
-  int forceDeleteStudent(@Param("studentId") byte[] studentId);
+  int forceDeleteStudent(@Param("studentId") UUID studentId);
 }

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -1,10 +1,8 @@
 package raisetech.student.management.repository;
 
 import java.util.List;
-
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-
 import raisetech.student.management.data.Student;
 
 /**
@@ -18,9 +16,9 @@ public interface StudentRepository {
   /**
    * 動的な検索条件（ふりがな、削除状態）に基づいて受講生情報を検索します。
    *
-   * @param furigana ふりがなによる部分一致検索条件（nullまたは空文字は無視）
+   * @param furigana       ふりがなによる部分一致検索条件（nullまたは空文字は無視）
    * @param includeDeleted 論理削除された受講生も含めるかどうか
-   * @param deletedOnly 論理削除された受講生のみ取得するかどうか
+   * @param deletedOnly    論理削除された受講生のみ取得するかどうか
    * @return 条件に一致する受講生情報のリスト
    */
   List<Student> searchStudents(
@@ -48,12 +46,12 @@ public interface StudentRepository {
    *
    * @param student 更新する受講生情報
    */
-  void updateStudent(Student student);
+  int updateStudent(Student student);
 
   /**
    * 受講生IDで該当する受講生情報を物理削除します。
    *
    * @param studentId 物理削除対象の受講生ID
    */
-  void forceDeleteStudent(@Param("studentId") byte[] studentId);
+  int forceDeleteStudent(@Param("studentId") byte[] studentId);
 }

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -1,6 +1,7 @@
 package raisetech.student.management.service;
 
 import java.util.List;
+import java.util.UUID;
 import org.springframework.transaction.annotation.Transactional;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
@@ -23,20 +24,20 @@ public interface StudentService {
    * @param student 更新対象の学生エンティティ（studentId は必須）
    * @param courses 更新後に紐づける受講コースの一覧（null/空配列は「0件に置換」）
    * @return 更新後の学生エンティティ
-   * @throws IllegalArgumentException                                         studentId が null の場合
-   * @throws raisetech.student.management.exception.ResourceNotFoundException 指定IDの学生が存在しない場合
+   * @throws IllegalArgumentException  studentId が null の場合
+   * @throws ResourceNotFoundException 指定IDの学生が存在しない場合
    */
   @Transactional
   Student updateStudentWithCourses(Student student, List<StudentCourse> courses);
 
   /**
-   * 学生IDに紐づく受講コース一覧を取得します。
+   * 受講生IDに紐づく受講コース一覧を取得します。
    *
-   * @param studentId 学生ID（BINARY(16)）
+   * @param studentId 受講生ID（UUID）
    * @return 受講コース一覧（0件の場合は空リスト）
    * @throws IllegalArgumentException studentId が null の場合
    */
-  List<StudentCourse> getCoursesByStudentId(byte[] studentId);
+  List<StudentCourse> getCoursesByStudentId(UUID studentId);
 
   // 既存メソッド群（例）
   // Student partialUpdateStudentWithCourses(...);
@@ -83,10 +84,10 @@ public interface StudentService {
    * <p>このメソッドは、すでに存在する {@code student_id + course_name} の組み合わせを 保持したまま、新たなコース情報だけをデータベースに登録します。
    * 既存のコースは削除されず、重複も防止されます。
    *
-   * @param studentId  受講生の識別子（UUID文字列表現）
+   * @param studentId  受講生の識別子（UUID）
    * @param newCourses 追加対象の新しいコース情報のリスト {@code studentId} に紐づけられている必要があります
    */
-  void appendCourses(byte[] studentId, List<StudentCourse> newCourses);
+  void appendCourses(UUID studentId, List<StudentCourse> newCourses);
 
   /**
    * 受講生情報のみを更新します（コース情報は変更しません）。
@@ -98,18 +99,18 @@ public interface StudentService {
   /**
    * 受講生IDにより受講生情報を取得します。
    *
-   * @param studentId 受講生ID
+   * @param studentId 受講生ID（UUID）
    * @return 受講生エンティティ
    */
-  Student findStudentById(byte[] studentId);
+  Student findStudentById(UUID studentId);
 
   /**
    * 受講生IDに紐づくコース情報を取得します。
    *
-   * @param studentId 受講生ID
+   * @param studentId 受講生ID（UUID）
    * @return コースエンティティのリスト
    */
-  List<StudentCourse> searchCoursesByStudentId(byte[] studentId);
+  List<StudentCourse> searchCoursesByStudentId(UUID studentId);
 
   /**
    * 全てのコース情報を取得します。
@@ -121,23 +122,23 @@ public interface StudentService {
   /**
    * 受講生を論理削除します。
    *
-   * @param studentId 受講生ID
+   * @param studentId 受講生ID（UUID）
    */
-  void softDeleteStudent(byte[] studentId);
+  void softDeleteStudent(UUID studentId);
 
   /**
    * 論理削除された受講生を復元します。
    *
-   * @param studentId 受講生ID
+   * @param studentId 受講生ID（UUID）
    */
-  void restoreStudent(byte[] studentId);
+  void restoreStudent(UUID studentId);
 
   /**
    * 受講生情報とそのコース情報を物理削除します（管理者専用）。
    *
-   * @param studentId 削除対象の受講生ID
+   * @param studentId 削除対象の受講生ID（UUID）
    */
-  void forceDeleteStudent(byte[] studentId);
+  void forceDeleteStudent(UUID studentId);
 
   /**
    * 指定した受講生の既存コースを全て削除し、与えられた一覧に置き換えます。
@@ -146,11 +147,11 @@ public interface StudentService {
    * 呼び出し側で {@code updateStudentInfoOnly(...)} 等の基本情報更新を別途行ってください。 また、レスポンスに返す際は最終状態を必ず DB
    * から再取得することを推奨します。
    *
-   * @param studentIdBytes UUID文字列表現の受講生ID（バイナリ）
-   * @param newCourses     置換後に保持するコース一覧（null/空の場合は「全削除のみ」）
+   * @param studentId  受講生ID（UUID）
+   * @param newCourses 置換後に保持するコース一覧（null/空の場合は「全削除のみ」）
    * @throws ResourceNotFoundException 該当受講生が存在しない場合
    * @implNote 各 {@code StudentCourse} の {@code studentId} は本メソッド内で安全のため再セットします。
    * @since 1.0
    */
-  void replaceCourses(byte[] studentIdBytes, List<StudentCourse> newCourses);
+  void replaceCourses(UUID studentId, List<StudentCourse> newCourses);
 }

--- a/src/main/java/raisetech/student/management/util/UUIDUtil.java
+++ b/src/main/java/raisetech/student/management/util/UUIDUtil.java
@@ -1,7 +1,6 @@
 package raisetech.student.management.util;
 
 import java.nio.ByteBuffer;
-import java.util.Base64;
 import java.util.UUID;
 
 /**
@@ -23,7 +22,9 @@ public class UUIDUtil {
    * @param uuid UUIDオブジェクト
    * @return UUIDのバイナリ表現（byte[16]）
    */
-  /** UUID -> 16バイト配列 */
+  /**
+   * UUID -> 16バイト配列
+   */
   public static byte[] fromUUID(UUID uuid) {
     if (uuid == null) {
       throw new IllegalArgumentException("UUIDはnullにできません");
@@ -49,118 +50,5 @@ public class UUIDUtil {
     long mostSigBits = buffer.getLong();
     long leastSigBits = buffer.getLong();
     return new UUID(mostSigBits, leastSigBits);
-  }
-
-  /**
-   * byte[] を URLセーフなBase64文字列にエンコードします（パディングなし）。
-   *
-   * @param bytes エンコード対象のバイナリデータ
-   * @return Base64エンコード文字列
-   */
-  public static String toBase64(byte[] bytes) {
-    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
-  }
-
-  /**
-   * URLセーフな Base64 文字列をバイナリデータ（byte[]）にデコードします。
-   *
-   * <p>例：UUIDのBase64文字列（パディングなし）を元のbyte[16]形式に変換します。
-   *
-   * <p>不正なBase64文字列が渡された場合は、詳細なメッセージを含む IllegalArgumentException をスローします。
-   *
-   * @param base64 デコード対象のBase64文字列（URLセーフ、パディングなし）
-   * @return デコードされたバイナリデータ（通常は UUID を表す byte[16]）
-   * @throws IllegalArgumentException Base64形式が不正な場合（例："illegal base64 character" 等）
-   */
-  public static byte[] fromBase64Raw(String base64) {
-    if (base64 == null || base64.isBlank()) {
-      throw new IllegalArgumentException("UUIDの形式が不正です");
-    }
-    // 1) URL-safe デコード（パディング補正）
-    try {
-      String normalized = padIfNeeded(base64);
-      return Base64.getUrlDecoder().decode(normalized);
-    } catch (IllegalArgumentException ignore) {
-      // 2) 通常Base64で再試行
-      try {
-        return Base64.getDecoder().decode(base64);
-      } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException("UUIDの形式が不正です", e);
-      }
-    }
-  }
-
-  // ========================
-  // 「UUIDとしての」Base64 ⇄ byte[16]/UUID
-  // ========================
-
-  /**
-   * Base64文字列（URLセーフ/通常のどちらでも可）を UUIDバイナリ（byte[16]）にデコードします。<br>
-   * 16バイトでない場合は IllegalArgumentException を投げます。
-   *
-   * @param base64 Base64文字列（URLセーフ推奨、パディングなしでも可）
-   * @return UUIDを表す byte[16]
-   * @throws IllegalArgumentException 形式不正または16バイト以外
-   */
-  public static byte[] fromBase64(String base64) {
-    try {
-      // URLセーフ/標準どちらでもOKにしたい場合は前処理で '-'→'+'、'_'→'/' など補正してから decode しても良い
-      byte[] bytes = Base64.getUrlDecoder().decode(base64);
-      if (bytes.length != 16) {
-        throw new IllegalArgumentException("UUIDの形式が不正です");
-      }
-      return bytes;
-    } catch (IllegalArgumentException ex) {
-      // Base64自体が不正な場合の文言
-      String msg = ex.getMessage();
-      if (msg == null || msg.isBlank()) {
-        msg = "Base64の形式が不正です";
-      }
-      throw new IllegalArgumentException(msg, ex);
-    }
-  }
-
-  /**
-   * UUIDをBase64文字列（URLセーフ、パディングなし）に変換します。
-   *
-   * @param uuid UUIDオブジェクト
-   * @return Base64文字列
-   */
-  public static String toBase64(UUID uuid) {
-    return toBase64(fromUUID(uuid));
-  }
-
-  /**
-   * Base64文字列（URLセーフ/通常）からUUIDを復元します。
-   *
-   * @param base64 Base64文字列（URLセーフ推奨、パディングなしでも可）
-   * @return UUIDオブジェクト
-   * @throws IllegalArgumentException 形式不正または16バイト以外
-   */
-  public static UUID fromBase64ToUUID(String base64) {
-    return toUUID(fromBase64(base64));
-  }
-
-  // ========================
-  // Helpers
-  // ========================
-
-  /** Base64の長さを4の倍数にするために '=' を補う（URLセーフのとき用）。 */
-  private static String padIfNeeded(String s) {
-    int mod = s.length() % 4;
-    return mod == 0 ? s : s + "=".repeat(4 - mod);
-  }
-
-  // ========================
-  // 動作確認用
-  // ========================
-
-  /** 動作確認用のmainメソッド。 Base64文字列からUUID形式を表示します。 */
-  public static void main(String[] args) {
-    String base64Id = "GdgYbbFeRU6A70yPTVUN2A"; // 例: Webで受け取ったID
-    UUID uuid = fromBase64ToUUID(base64Id);
-    System.out.println("Base64: " + base64Id);
-    System.out.println("UUID:   " + uuid);
-    System.out.println("Back to Base64: " + toBase64(uuid));
   }
 }

--- a/src/main/java/raisetech/student/management/util/UUIDUtil.java
+++ b/src/main/java/raisetech/student/management/util/UUIDUtil.java
@@ -54,4 +54,28 @@ public class UUIDUtil {
     long leastSigBits = buffer.getLong();
     return new UUID(mostSigBits, leastSigBits);
   }
+
+  /**
+   * 文字列表現の UUID を BINARY(16) 用の byte 配列に変換します。
+   *
+   * @param uuidString 標準形式の UUID 文字列（例: 550e8400-e29b-41d4-a716-446655440000）
+   * @return UUID を表す 16 バイトの配列
+   */
+  public static byte[] toBytes(String uuidString) {
+    if (uuidString == null) {
+      throw new IllegalArgumentException("uuidString must not be null");
+    }
+    return toBytes(UUID.fromString(uuidString));
+  }
+
+  /**
+   * BINARY(16) の byte 配列を標準形式の UUID 文字列に変換します。
+   *
+   * @param bytes 16 バイトの配列
+   * @return 標準形式の UUID 文字列（例: 550e8400-e29b-41d4-a716-446655440000）
+   */
+  public static String toString(byte[] bytes) {
+    UUID uuid = fromBytes(bytes);
+    return uuid != null ? uuid.toString() : null;
+  }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,7 @@ spring.jpa.hibernate.ddl-auto=update
 # MyBatis
 mybatis.configuration.map-underscore-to-camel-case=true
 mybatis.configuration.log-impl=org.apache.ibatis.logging.stdout.StdOutImpl
-mybatis.mapper-locations=classpath:mappers/*.xml
+mybatis.mapper-locations=classpath*:mappers/**/*.xml
 mybatis.type-aliases-package=raisetech.student.management.data
 mybatis.type-handlers-package=raisetech.student.management.config.typehandler
 # HikariCP

--- a/src/main/resources/mappers/StudentCourseRepository.xml
+++ b/src/main/resources/mappers/StudentCourseRepository.xml
@@ -19,9 +19,9 @@
     <foreach collection="list" item="course" separator=",">
       (
       #{course.courseId, jdbcType=BINARY,
-      typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
+      typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler},
       #{course.studentId, jdbcType=BINARY,
-      typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
+      typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler},
       #{course.courseName},
       #{course.startDate},
       #{course.endDate},
@@ -35,8 +35,8 @@
     INSERT INTO student_courses (course_id, student_id, course_name, start_date, end_date,
     created_at)
     SELECT
-    #{courseId, jdbcType=BINARY, typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
-    #{studentId, jdbcType=BINARY, typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
+    #{courseId, jdbcType=BINARY, typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler},
+    #{studentId, jdbcType=BINARY, typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler},
     #{courseName},
     #{startDate},
     #{endDate},
@@ -52,14 +52,14 @@
   <!-- 削除 -->
   <delete id="deleteCoursesByStudentId" parameterType="byte[]">
     DELETE FROM student_courses WHERE student_id = #{studentId, jdbcType=BINARY,
-    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler}
+    typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler}
   </delete>
 
   <!-- 特定の受講生のコースを取得 -->
   <select id="findCoursesByStudentId" parameterType="byte[]"
     resultType="raisetech.student.management.data.StudentCourse">
     SELECT * FROM student_courses WHERE student_id = #{studentId, jdbcType=BINARY,
-    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler}
+    typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler}
   </select>
 
   <!-- 全件取得 -->

--- a/src/main/resources/mappers/StudentCourseRepository.xml
+++ b/src/main/resources/mappers/StudentCourseRepository.xml
@@ -17,22 +17,23 @@
     )
     VALUES
     <foreach collection="list" item="course" separator=",">
-    (
-    #{course.courseId, jdbcType=BINARY,
-    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
-    #{course.studentId, jdbcType=BINARY,
-    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
-    #{course.courseName},
-    #{course.startDate},
-    #{course.endDate},
-    NOW()
-    )
+      (
+      #{course.courseId, jdbcType=BINARY,
+      typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
+      #{course.studentId, jdbcType=BINARY,
+      typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
+      #{course.courseName},
+      #{course.startDate},
+      #{course.endDate},
+      NOW()
+      )
     </foreach>
   </insert>
 
   <!-- 部分追加（登録） -->
   <insert id="insertIfNotExists" parameterType="StudentCourse">
-    INSERT INTO student_courses (course_id, student_id, course_name, start_date, end_date, created_at)
+    INSERT INTO student_courses (course_id, student_id, course_name, start_date, end_date,
+    created_at)
     SELECT
     #{courseId, jdbcType=BINARY, typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
     #{studentId, jdbcType=BINARY, typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
@@ -55,7 +56,8 @@
   </delete>
 
   <!-- 特定の受講生のコースを取得 -->
-  <select id="findCoursesByStudentId" parameterType="byte[]" resultType="raisetech.student.management.data.StudentCourse">
+  <select id="findCoursesByStudentId" parameterType="byte[]"
+    resultType="raisetech.student.management.data.StudentCourse">
     SELECT * FROM student_courses WHERE student_id = #{studentId, jdbcType=BINARY,
     typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler}
   </select>

--- a/src/main/resources/mappers/StudentCourseRepository.xml
+++ b/src/main/resources/mappers/StudentCourseRepository.xml
@@ -5,6 +5,17 @@
 
 <mapper namespace="raisetech.student.management.repository.StudentCourseRepository">
 
+  <resultMap id="StudentCourseResultMap" type="raisetech.student.management.data.StudentCourse">
+    <result property="courseId" column="course_id" jdbcType="BINARY"
+      typeHandler="raisetech.student.management.config.typehandler.UUIDTypeHandler"/>
+    <result property="studentId" column="student_id" jdbcType="BINARY"
+      typeHandler="raisetech.student.management.config.typehandler.UUIDTypeHandler"/>
+    <result property="courseName" column="course_name"/>
+    <result property="startDate" column="start_date"/>
+    <result property="endDate" column="end_date"/>
+    <result property="createdAt" column="created_at"/>
+  </resultMap>
+
   <!-- 登録 -->
   <insert id="insertCourses" parameterType="java.util.List">
     INSERT INTO student_courses (
@@ -50,20 +61,20 @@
   </insert>
 
   <!-- 削除 -->
-  <delete id="deleteCoursesByStudentId" parameterType="byte[]">
+  <delete id="deleteCoursesByStudentId">
     DELETE FROM student_courses WHERE student_id = #{studentId, jdbcType=BINARY,
     typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler}
   </delete>
 
   <!-- 特定の受講生のコースを取得 -->
-  <select id="findCoursesByStudentId" parameterType="byte[]"
+  <select id="findCoursesByStudentId"
     resultType="raisetech.student.management.data.StudentCourse">
     SELECT * FROM student_courses WHERE student_id = #{studentId, jdbcType=BINARY,
     typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler}
   </select>
 
   <!-- 全件取得 -->
-  <select id="findAllCourses" resultType="raisetech.student.management.data.StudentCourse">
+  <select id="findAllCourses" resultMap="StudentCourseResultMap">
     SELECT * FROM student_courses
   </select>
 

--- a/src/main/resources/mappers/StudentRepository.xml
+++ b/src/main/resources/mappers/StudentRepository.xml
@@ -42,7 +42,7 @@
   </select>
 
   <!-- ID検索 -->
-  <select id="findById" resultMap="StudentResultMap" parameterType="byte[]">
+  <select id="findById" resultMap="StudentResultMap">
     SELECT * FROM students WHERE student_id = #{studentId, jdbcType=BINARY,
     typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler}
   </select>
@@ -75,7 +75,7 @@
   </update>
 
   <!-- 物理削除 -->
-  <delete id="forceDeleteStudent" parameterType="byte[]">
+  <delete id="forceDeleteStudent">
     DELETE FROM students WHERE student_id = #{studentId, jdbcType=BINARY,
     typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler}
   </delete>

--- a/src/main/resources/mappers/StudentRepository.xml
+++ b/src/main/resources/mappers/StudentRepository.xml
@@ -8,7 +8,7 @@
   <!-- 共通のマッピング -->
   <resultMap id="StudentResultMap" type="raisetech.student.management.data.Student">
     <result property="studentId" column="student_id" jdbcType="BINARY"
-      typeHandler="raisetech.student.management.config.typehandler.ByteArrayTypeHandler"/>
+      typeHandler="raisetech.student.management.config.typehandler.UUIDTypeHandler"/>
     <result property="fullName" column="full_name"/>
     <result property="furigana" column="furigana"/>
     <result property="nickname" column="nickname"/>
@@ -44,7 +44,7 @@
   <!-- ID検索 -->
   <select id="findById" resultMap="StudentResultMap" parameterType="byte[]">
     SELECT * FROM students WHERE student_id = #{studentId, jdbcType=BINARY,
-    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler}
+    typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler}
   </select>
 
   <!-- 挿入 -->
@@ -52,7 +52,7 @@
     INSERT INTO students (student_id, full_name, furigana, nickname, email, location,
     age, gender, remarks, created_at, is_deleted)
     VALUES (#{studentId, jdbcType=BINARY,
-    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler},
+    typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler},
     #{fullName}, #{furigana}, #{nickname}, #{email}, #{location}, #{age}, #{gender}, #{remarks},
     now(), #{deleted})
   </insert>
@@ -71,13 +71,13 @@
     is_deleted = #{deleted},
     deleted_at = #{deletedAt}
     WHERE student_id = #{studentId, jdbcType=BINARY,
-    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler}
+    typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler}
   </update>
 
   <!-- 物理削除 -->
   <delete id="forceDeleteStudent" parameterType="byte[]">
     DELETE FROM students WHERE student_id = #{studentId, jdbcType=BINARY,
-    typeHandler=raisetech.student.management.config.typehandler.ByteArrayTypeHandler}
+    typeHandler=raisetech.student.management.config.typehandler.UUIDTypeHandler}
   </delete>
 
 </mapper>

--- a/src/main/resources/mappers/StudentRepository.xml
+++ b/src/main/resources/mappers/StudentRepository.xml
@@ -7,7 +7,8 @@
 
   <!-- 共通のマッピング -->
   <resultMap id="StudentResultMap" type="raisetech.student.management.data.Student">
-    <result property="studentId" column="student_id"/>
+    <result property="studentId" column="student_id" jdbcType="BINARY"
+      typeHandler="raisetech.student.management.config.typehandler.ByteArrayTypeHandler"/>
     <result property="fullName" column="full_name"/>
     <result property="furigana" column="furigana"/>
     <result property="nickname" column="nickname"/>

--- a/src/test/java/raisetech/student/management/controller/AdminStudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/AdminStudentControllerTest.java
@@ -1,0 +1,107 @@
+package raisetech.student.management.controller;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import raisetech.student.management.exception.ResourceNotFoundException;
+
+/**
+ * {@link raisetech.student.management.controller.admin.AdminStudentController} の振る舞いを検証するテスト。
+ *
+ * <p>{@link ControllerTestBase} を継承し、MockMvc と @MockBean の
+ * StudentService / StudentConverter を共有して利用します。
+ */
+class AdminStudentControllerTest extends ControllerTestBase {
+
+  /**
+   * 正常系: 正しい UUID を指定し、サービス層が例外を投げなかった場合、 204 No Content が返ることを検証します。
+   */
+  @Test
+  void forceDeleteStudent_正常系_204が返ること() throws Exception {
+    // given
+    String idStr = studentById; // ControllerTestBase で用意している UUID 文字列
+    UUID idUuid = studentId;    // 同じく Base で用意している UUID
+
+    // UUID文字列 → UUID へのデコード
+    when(converter.decodeUuidStringOrThrow(idStr)).thenReturn(idUuid);
+    // サービスは例外を投げずに正常終了（void メソッドなので doNothing）
+    doNothing().when(service).forceDeleteStudent(idUuid);
+
+    // when & then
+    mockMvc
+        .perform(delete("/admin/students/{studentId}", idStr))
+        .andExpect(status().isNoContent());
+
+    // 呼び出し検証
+    verify(converter).decodeUuidStringOrThrow(idStr);
+    verify(service).forceDeleteStudent(idUuid);
+  }
+
+  /**
+   * 異常系: UUID 文字列として不正な ID を指定した場合、 400 Bad Request / E006 が返ることを検証します。
+   *
+   * <p>GlobalExceptionHandler のマッピングに合わせて assertion を調整してください。
+   */
+  @Test
+  void forceDeleteStudent_UUID形式として不正なIDを指定した場合_400が返ること() throws Exception {
+    String invalid = "@@invalid@@";
+
+    // デコード時点で形式不正として例外を投げる想定
+    when(converter.decodeUuidStringOrThrow(invalid))
+        .thenThrow(new IllegalArgumentException("IDの形式が不正です（UUID）"));
+
+    mockMvc
+        .perform(delete("/admin/students/{studentId}", invalid))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.code").value("E006"))              // プロジェクト仕様に合わせる
+        .andExpect(jsonPath("$.error").value("INVALID_REQUEST"))  // ここも仕様にあわせて
+        .andExpect(
+            jsonPath("$.message").value(org.hamcrest.Matchers.containsString("IDの形式が不正")));
+
+    verify(converter).decodeUuidStringOrThrow(invalid);
+    // デコードで落ちるので service は呼ばれない想定
+    verifyNoInteractions(service);
+  }
+
+  /**
+   * 異常系: 存在しない ID を指定した場合、 サービス層が ResourceNotFoundException をスローし、 404 NOT_FOUND / E404
+   * が返ることを検証します。
+   */
+  @Test
+  void forceDeleteStudent_存在しないIDを指定した場合_404が返ること() throws Exception {
+    String idStr = studentById;
+    UUID idUuid = studentId;
+
+    when(converter.decodeUuidStringOrThrow(idStr)).thenReturn(idUuid);
+    // サービス側で 404 相当のドメイン例外をスロー
+    doThrow(new ResourceNotFoundException("student", "studentId"))
+        .when(service).forceDeleteStudent(idUuid);
+
+    mockMvc
+        .perform(delete("/admin/students/{studentId}", idStr))
+        .andExpect(status().isNotFound())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.code").value("E404"))        // GlobalExceptionHandler に合わせる
+        .andExpect(jsonPath("$.error").value("NOT_FOUND"))
+        .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("student")));
+
+    verify(converter).decodeUuidStringOrThrow(idStr);
+    verify(service).forceDeleteStudent(idUuid);
+  }
+}
+
+
+

--- a/src/test/java/raisetech/student/management/controller/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/student/management/controller/converter/StudentConverterTest.java
@@ -2,17 +2,15 @@ package raisetech.student.management.controller.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
@@ -20,7 +18,6 @@ import raisetech.student.management.dto.StudentCourseDto;
 import raisetech.student.management.dto.StudentDetailDto;
 import raisetech.student.management.dto.StudentDto;
 import raisetech.student.management.exception.InvalidIdFormatException;
-import raisetech.student.management.util.IdCodec;
 
 /**
  * {@link StudentConverter} の単体テストクラス。
@@ -33,69 +30,26 @@ import raisetech.student.management.util.IdCodec;
  *   <li>部分更新マージ処理（{@link StudentConverter#mergeStudent(Student, Student)}）</li>
  * </ul>
  *
- * <p>{@link IdCodec} はモック化し、UUID の具体的な値や UUID文字列 実装詳細に依存しない形で
- * コンバータの責務のみを検証します。
  */
 @ExtendWith(MockitoExtension.class)
 class StudentConverterTest {
 
   /**
-   * ID 変換処理を委譲するユーティリティのモック。
-   *
-   * <p>UUID 16 バイトと UUID 文字列の相互変換ロジックは本クラスの関心外とし、
-   * その戻り値／例外を固定することで {@link StudentConverter} の挙動を検証します。
-   */
-  @Mock
-  IdCodec idCodec;
-
-  /**
    * テスト対象となるコンバータ。
-   *
-   * <p>{@link IdCodec} モックが自動的にインジェクションされます。
    */
   @InjectMocks
   private StudentConverter converter;
 
-  /**
-   * テスト共通で利用する 「UUID の生バイト表現」を示す16 バイト固定 ID（学生 A 用）。
-   *
-   * <p>値そのもの（ビットパターン）はテストの関心外であり、
-   * 「常に16バイトの UUID/BINARY(16) である」ことだけを保証したいケースで利用します。
-   */
-  private final byte[] FIXED_UUID_BYTES = new byte[]{
-      (byte) 0x12, (byte) 0x34, (byte) 0x56, (byte) 0x78,
-      (byte) 0x9a, (byte) 0xbc, (byte) 0xde, (byte) 0xf0,
-      (byte) 0x12, (byte) 0x34, (byte) 0x56, (byte) 0x78,
-      (byte) 0x9a, (byte) 0xbc, (byte) 0xde, (byte) 0xf0
-  };
-
   // テスト用の固定UUID文字列
-  private static final String FIXED_UUID_STRING = "123e4567-e89b-12d3-a456-426614174000";
+  private static final String UUID_STRING = "123e4567-e89b-12d3-a456-426614174000";
+  private static final String UUID_STRING_B = "123e4567-e89b-12d3-a456-426614174001";
+  private UUID uuid;
 
-  /**
-   * 新規採番を想定した 「UUID の生バイト表現」を示す16 バイトの固定 ID。
-   *
-   * <p>{@link IdCodec#generateNewIdBytes()} の戻り値として利用し、
-   * 「ランダムだが 16 バイトである」という前提をテストに与えます。
-   */
-  private final byte[] NEW_RANDOM_BYTES = new byte[]{
-      (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
-      (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08,
-      (byte) 0x09, (byte) 0x0A, (byte) 0x0B, (byte) 0x0C,
-      (byte) 0x0D, (byte) 0x0E, (byte) 0x0F, (byte) 0x10
-  };
 
-  /**
-   * テスト内で使用する「UUID の生バイト表現」を示す学生 B 用の 16 バイト固定 ID。
-   */
-  private final byte[] FIXED_UUID_BYTES_B = new byte[]{
-      (byte) 0xaa, (byte) 0xbb, (byte) 0xcc, (byte) 0xdd,
-      (byte) 0xee, (byte) 0xff, (byte) 0x11, (byte) 0x22,
-      (byte) 0xaa, (byte) 0xbb, (byte) 0xcc, (byte) 0xdd,
-      (byte) 0xee, (byte) 0xff, (byte) 0x11, (byte) 0x22
-  };
-
-  private static final String FIXED_UUID_STRING_B = "123e4567-e89b-12d3-a456-426614174001";
+  @BeforeEach
+  void setUp() {
+    uuid = UUID.fromString(UUID_STRING);
+  }
 
   // ------------------------------------------------------------
   // ID変換メソッドのテスト
@@ -108,76 +62,49 @@ class StudentConverterTest {
   class IdConversionTest {
 
     /**
-     * {@link StudentConverter#encodeUuidString(byte[])} が 16 バイトの UUID バイト配列を正しく UUID
-     * 文字列へ変換し、{@link IdCodec#encodeId(byte[])} へ委譲されていることを検証します。
+     * {@link StudentConverter#encodeUuidString(UUID)} が UUID を標準的な文字列表現に変換できることを検証します。
+     *
+     * <p>内部の実装詳細（どのユーティリティを使うか）には依存せず、
+     * 「与えた UUID から期待通りの文字列が返るか」にフォーカスしたテストです。
      */
     @Test
-    void encodeUuidString_正常系_16バイトのUUIDバイト配列を正しくエンコードできること() {
-      // テストコードを実装 (FIXED_UUID_BYTES, FIXED_UUID_STRINGを使用)
-      // 固定値の16バイトのUUIDデータ
-      // 期待される UUID 文字列
-      // IdCodec に委譲されること＋戻り値がそのまま返ることを確認
-      when(idCodec.encodeId(FIXED_UUID_BYTES)).thenReturn(FIXED_UUID_STRING);
+    void encodeUuidString_正常系_UUIDを文字列に変換できること() {
 
-      String result = converter.encodeUuidString(FIXED_UUID_BYTES);
+      String actual = converter.encodeUuidString(uuid);
       // 期待値と結果が完全に一致することを確認
       // FIXED_UUID_BYTESのUUIDエンコード値
-      assertThat(result).isEqualTo(FIXED_UUID_STRING);
+      assertThat(actual).isEqualTo(UUID_STRING);
+    }
+
+    @Test
+    void decodeUuidStringOrThrow_正常系_UUID文字列をUUIDに変換できること() {
+      UUID actual = converter.decodeUuidStringOrThrow(UUID_STRING);
+
+      assertThat(actual).isEqualTo(UUID.fromString(UUID_STRING));
     }
 
     /**
-     * {@link StudentConverter#encodeUuidString(byte[])} に 16 バイト以外の配列が渡された場合、 内部で利用する
-     * {@link IdCodec#encodeId(byte[])} から {@link IllegalArgumentException} が そのまま伝播することを検証します。
+     * {@link StudentConverter# decodeUuidOrThrow(String)} にnullや空文字が渡された場合、
+     * {@link InvalidIdFormatException}（「" "」）がスローされることを検証します。
      */
     @Test
-    void encodeUuidString_異常系_16バイト以外の長さが入力された場合に例外が発生すること() {
-      // テストコードを実装 (IllegalArgumentException)
-      // 不正な長さのデータ（例: 4バイト）
-      byte[] invalidLengthBytes = new byte[]{0x01, 0x02, 0x03, 0x04};
+    void decodeUuidStringOrThrow_異常系_nullや空文字ならInvalidIdFormatException() {
+      assertThatThrownBy(() -> converter.decodeUuidStringOrThrow(null))
+          .isInstanceOf(InvalidIdFormatException.class);
 
-      // 16バイトチェックは IdCodec 側の責務とし、Converter は例外をそのまま伝播する
-      when(idCodec.encodeId(invalidLengthBytes))
-          .thenThrow(new IllegalArgumentException("UUIDの形式が不正です"));
+      assertThatThrownBy(() -> converter.decodeUuidStringOrThrow("  "))
+          .isInstanceOf(InvalidIdFormatException.class);
+    }
 
-      // 特定の例外（InvalidIdFormatException）がスローされることを確認
-      // （このチェックは Converter 側で行っているので、IdCodec のモックは不要）
-      assertThatThrownBy(() -> converter.encodeUuidString(invalidLengthBytes))
+    @Test
+    void decodeUuidStringOrThrow_異常系_不正なUUID文字列ならInvalidIdFormatException() {
+      assertThatThrownBy(() -> converter.decodeUuidStringOrThrow("not-a-uuid"))
           .isInstanceOf(InvalidIdFormatException.class)
-          .hasMessageContaining("IDの形式が不正です（UUIDバイト長が不正など）");
-    }
-
-    /**
-     * {@link StudentConverter#decodeUuidStringToBytesOrThrow(String)} が 正常な UUID 文字列を正しくバイト配列へ復元し、
-     * {@link IdCodec#decodeUuidBytesOrThrow(String)} に委譲していることを検証します。
-     */
-    @Test
-    void decodeUuidToBytesOrThrow_正常系_UUID文字列を正しくバイト配列にデコードできること() {
-      // テストコードを実装
-      String uuidString = FIXED_UUID_STRING; // "123e4567-e89b-12d3-a456-426614174000" など
-      when(idCodec.decodeUuidBytesOrThrow(uuidString)).thenReturn(FIXED_UUID_BYTES);
-
-      byte[] resultBytes = converter.decodeUuidStringToBytesOrThrow(uuidString);
-      // バイト配列の内容が一致することを確認
-      assertThat(resultBytes).containsExactly(FIXED_UUID_BYTES);
-    }
-
-    /**
-     * {@link StudentConverter# decodeUuidBytesOrThrow(String)} に不正な UUID 文字列が渡された場合、
-     * {@link InvalidIdFormatException}（「（UUID）」）がスローされることを検証します。
-     */
-    @Test
-    void decodeUuidToBytesOrThrow_異常系_不正なUUIDが入力された場合にInvalidIdFormatExceptionがスローされること() {
-      String invalid = "invalid!!";
-      when(idCodec.decodeUuidBytesOrThrow(invalid))
-          .thenThrow(new IllegalArgumentException("dummy"));
-
-      assertThatThrownBy(() -> converter.decodeUuidStringToBytesOrThrow(invalid))
-          .isInstanceOf(InvalidIdFormatException.class)
-          .hasMessageContaining("（UUID）"); // メッセージは実装に合わせて
+          .hasMessageContaining("IDの形式が不正です");
     }
   }
 
-  // ------------------------------------------------------------
+// ------------------------------------------------------------
 //　DTO ⇔ エンティティ 変換メソッドのテスト
 // ------------------------------------------------------------
 
@@ -197,27 +124,22 @@ class StudentConverterTest {
 
     /**
      * {@link StudentConverter#toEntity(StudentDto)} が、 ID 付きの {@link StudentDto} を正しく
-     * {@link Student} へ変換し、 ID デコードを {@link IdCodec#decodeUuidBytesOrThrow(String)}
-     * に委譲していることを検証します。
+     * {@link Student} へ変換していることを検証します。
      */
     @Test
     void toEntity_StudentDto_IDあり_全フィールドが正しくマッピングされIDがデコードされること() {
-      // IdCodec のモックで ID デコード結果を固定し、項目移送を検証する
       StudentDto inputDto = new StudentDto(
-          FIXED_UUID_STRING,
+          UUID_STRING,
           "山田 太郎", "ヤマダ タロウ", "Taro", "taro@example.com",
           "Tokyo", 25, "Male", "備考", false
       );
-
-      // IDデコードは IdCodec に委譲される
-      when(idCodec.decodeUuidBytesOrThrow(FIXED_UUID_STRING)).thenReturn(FIXED_UUID_BYTES);
 
       // 変換実行
       Student result = converter.toEntity(inputDto);
 
       // 検証
       // 1. IDが正しくデコードされているか
-      assertThat(result.getStudentId()).containsExactly(FIXED_UUID_BYTES);
+      assertThat(result.getStudentId()).isEqualTo(UUID.fromString(UUID_STRING));
       // 2. 他のフィールドが正しくマッピングされているか
       assertThat(result.getFullName()).isEqualTo("山田 太郎");
       assertThat(result.getFurigana()).isEqualTo("ヤマダ タロウ");
@@ -231,8 +153,8 @@ class StudentConverterTest {
     }
 
     /**
-     * {@link StudentConverter#toEntity(StudentDto)} において、 ID が未指定の場合（null）のときに
-     * {@link IdCodec#generateNewIdBytes()} が呼び出され、 新規 ID が採番されることを検証します。
+     * {@link StudentConverter#toEntity(StudentDto)} において、 ID が未指定の場合（null）のときに 新規 ID
+     * が採番されることを検証します。
      */
     @Test
     void toEntity_StudentDto_IDなし_新規にランダムIDが生成されること() {
@@ -243,42 +165,36 @@ class StudentConverterTest {
           "Tokyo", 25, "Male", "備考", false
       );
 
-      // 新規ID生成は IdCodec に委譲される
-      when(idCodec.generateNewIdBytes()).thenReturn(NEW_RANDOM_BYTES);
-
       // 変換実行
       Student result = converter.toEntity(inputDto);
 
       // 検証
       // 1. 新しいIDがセットされているか
-      assertThat(result.getStudentId()).containsExactly(NEW_RANDOM_BYTES);
+      assertThat(result.getStudentId()).isNotNull();
       // 2. 正しくマッピングされているか
       assertThat(result.getFullName()).isEqualTo("山田 太郎");
     }
 
     /**
-     * {@link StudentConverter#toDto(Student)} が {@link Student} の全フィールドを {@link StudentDto}
-     * へ正しくコピーし、 ID 部分のエンコードに {@link IdCodec#encodeId(byte[])} を利用していることを検証します。
+     * {@link StudentConverter#toDto(Student)} が {@link Student} の全フィールドを
+     * {@link StudentDto}へ正しくコピーしていることを検証します。
      */
     @Test
     void toDto_Student_正常系_全フィールドが正しくマッピングされIDがエンコードされること() {
+      UUID id = UUID.fromString(UUID_STRING);
       // IDありのDTOを準備
       Student input = new Student(
-          FIXED_UUID_BYTES,
+          id,
           "山田 太郎", "ヤマダ タロウ", "Taro", "taro@example.com",
           "Tokyo", 25, "Male", "備考", null, null, false
       );
-
-      // --- When (変換実行) ---
-      // toDto を実行し、結果を StudentDto で受け取る
-      when(idCodec.encodeId(FIXED_UUID_BYTES)).thenReturn(FIXED_UUID_STRING);
 
       StudentDto dto = converter.toDto(input);
 
       // --- Then (検証) ---
       // DTO 内容の検証
       // 1. IDが正しくエンコードされているか
-      assertThat(dto.getStudentId()).isEqualTo(FIXED_UUID_STRING);
+      assertThat(dto.getStudentId()).isEqualTo(UUID_STRING);
       // 2. 他のフィールドが正しくマッピングされているか
       assertThat(dto.getFullName()).isEqualTo("山田 太郎");
       assertThat(dto.getFurigana()).isEqualTo("ヤマダ タロウ");
@@ -292,125 +208,78 @@ class StudentConverterTest {
     }
 
     /**
-     * {@link StudentConverter#toDto(Student)} において、学生 ID が 16 バイト未満の場合、 内部で呼び出される
-     * {@link IdCodec#encodeId(byte[])} が {@link IllegalArgumentException} を投げ、 それが
-     * {@link InvalidIdFormatException} にラップされてコンバータから伝播することを検証します。
-     */
-    @Test
-    void toDto_Student_異常系_ID長が16バイトでない場合にInvalidIdFormatExceptionがスローされること() {
-      // 💡 異常系データ: 15バイトのIDを持つバイト配列を作成
-      byte[] invalid = new byte[]{
-          0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-          0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f // 合計15バイト (16バイト未満)
-      };
-
-      // 💡 この不正なIDを持つStudentエンティティを作成
-      Student input = new Student(
-          invalid, "テスト", "テスト", "Test", "test@test.com",
-          "Tokyo", 20, "Male", "備考", null, null, false
-      );
-
-      // ★ IdCodec が長さ不正を検知して IllegalArgumentException を投げるようにスタブ
-      when(idCodec.encodeId(invalid))
-          .thenThrow(new IllegalArgumentException("UUIDの形式が不正です"));
-
-      // toDtoメソッドは内部でencodeIdを呼び出し、ID長が16バイトでないため例外が発生する
-      assertThatThrownBy(() -> converter.toDto(input))
-          .isInstanceOf(InvalidIdFormatException.class)
-          .hasMessageContaining("IDの形式が不正です");
-
-      // ★ ちゃんと IdCodec が呼ばれていることも確認しておくと安心
-      verify(idCodec).encodeId(invalid);
-    }
-
-    /**
      * {@link StudentConverter#toEntity(StudentCourseDto, String)} において、 コース ID
      * が未指定（null）の場合、新規採番された ID が利用されることを検証します。
      */
     @Test
     void toEntity_StudentCourseDto_CourseIDなし_StudentCourseが新規IDで生成されること() {
-      // Course IDの新規採番ロジックをテスト
-      // Student IDのUUID文字列 (紐付け用)
-      final String uuidString = FIXED_UUID_STRING;
+      LocalDate start = LocalDate.of(2025, 4, 1);
+      LocalDate end = LocalDate.of(2025, 9, 30);
 
       // --- Given (入力データの準備) ---
       // Course IDが null の入力 DTO を準備
       StudentCourseDto inputDto = new StudentCourseDto(
           null, // ★ CourseId を null に設定
-          "Javaコース", LocalDate.of(2025, 4, 1), LocalDate.of(2025, 9, 30)
-          // LocalDate オブジェクトとして渡す
+          "Javaコース",
+          start,
+          end
       );
 
-      // --- Mocking (新規ID生成の動作を定義) ---
-      // 新規Course ID
-      when(idCodec.generateNewIdBytes()).thenReturn(NEW_RANDOM_BYTES);
-
-      // Student IDのデコード結果（UUID 16バイトとして扱う）
-      byte[] fixedStudentBytes = new byte[16]; // 紐付け用 学生IDのバイト配列
-      when(idCodec.decodeUuidBytesOrThrow(uuidString)).thenReturn(fixedStudentBytes);
-
       // --- When (変換実行) ---
-      // 正しいメソッドと引数 (DTO, uuidString) で呼び出し
-      // 戻り値の型は StudentCourse (エンティティ)
-      StudentCourse result = converter.toEntity(inputDto, uuidString);
+      // パスから渡ってきた想定の studentId（UUID文字列）
+      String studentIdString = UUID_STRING;
+      UUID studentId = UUID.fromString(studentIdString);
 
-      // --- Then (検証) ---
-      // 1. 新しいIDがセットされているか
-      // resultEntity は StudentCourse (エンティティ) なので、IDはバイト配列
-      // resultEntity.getCourseId() は byte[] 型なので isEqualTo を使用
-      assertThat(result.getCourseId()).containsExactly(NEW_RANDOM_BYTES);
-      // 2. Student IDが正しく紐づいているか
-      assertThat(result.getStudentId()).containsExactly(fixedStudentBytes);
-      // 3.　他のフィールドが正しくマッピングされているか
+      StudentCourse result = converter.toEntity(inputDto, studentIdString);
+
+      assertThat(result.getCourseId()).isNotNull();           // ランダム採番されている
+      assertThat(result.getStudentId()).isEqualTo(studentId); // 正しく紐づいている
       assertThat(result.getCourseName()).isEqualTo("Javaコース");
-      assertThat(result.getStartDate()).isEqualTo(LocalDate.of(2025, 4, 1));
-      assertThat(result.getEndDate()).isEqualTo(LocalDate.of(2025, 9, 30));
+      assertThat(result.getStartDate()).isEqualTo(start);
+      assertThat(result.getEndDate()).isEqualTo(end);
     }
 
     /**
-     * {@link StudentConverter#toEntityList(List, byte[])} において、 各 {@link StudentCourseDto} に既存のコース
-     * ID が指定されている場合、 それぞれが正しくデコードされて {@link StudentCourse} に反映されることを検証します。
+     * {@link StudentConverter#toEntityList(List, java.util.UUID)} において、 各 {@link StudentCourseDto}
+     * に既存のコース ID が指定されている場合、 それぞれが正しくデコードされて {@link StudentCourse} に反映されることを検証します。
      */
     @Test
-    void toEntityList_StudentCourseDto_CourseIDあり_既存IDが正しくデコードされて使用されること() {
-      // --- Given ---
-      byte[] studentIdBytes = FIXED_UUID_BYTES; // 紐付け先の受講生ID（UUIDの16バイト）
+    void toEntityList_StudentCourseDto_CourseIDあり_既存IDが正しく使用されること() {
+      LocalDate start = LocalDate.of(2025, 4, 1);
 
-      List<StudentCourseDto> dtoList = getStudentCourseDtos();
+      StudentCourseDto dto1 = new StudentCourseDto(
+          UUID_STRING,
+          "Javaコース",
+          start,
+          start.plusMonths(6)
+      );
+      StudentCourseDto dto2 = new StudentCourseDto(
+          UUID_STRING_B,
+          "SQLコース",
+          start,
+          start.plusMonths(3)
+      );
 
-      // IdCodec による CourseId の復号結果をモック
-      // UUID → UUID 16バイト
-      when(idCodec.decodeUuidBytesOrThrow(FIXED_UUID_STRING)).thenReturn(FIXED_UUID_BYTES);
-      when(idCodec.decodeUuidBytesOrThrow(FIXED_UUID_STRING_B)).thenReturn(FIXED_UUID_BYTES_B);
+      UUID studentId = UUID.randomUUID();
 
-      // --- When ---
-      List<StudentCourse> result = converter.toEntityList(dtoList, studentIdBytes);
+      List<StudentCourse> result = converter.toEntityList(List.of(dto1, dto2), studentId);
 
-      // --- Then ---
       assertThat(result).hasSize(2);
 
-      // コース名で取り出して検証（順序にあまり依存したくない場合）
       StudentCourse courseJava = result.stream()
           .filter(c -> c.getCourseName().equals("Javaコース"))
           .findFirst()
           .orElseThrow();
-
       StudentCourse courseSql = result.stream()
           .filter(c -> c.getCourseName().equals("SQLコース"))
           .findFirst()
           .orElseThrow();
 
-      // 1. CourseId がそれぞれ正しくデコードされていること
-      assertThat(courseJava.getCourseId()).containsExactly(FIXED_UUID_BYTES);
-      assertThat(courseSql.getCourseId()).containsExactly(FIXED_UUID_BYTES_B);
+      assertThat(courseJava.getCourseId()).isEqualTo(UUID.fromString(UUID_STRING));
+      assertThat(courseSql.getCourseId()).isEqualTo(UUID.fromString(UUID_STRING_B));
 
-      // 2. どちらのコースも同じ studentId に紐づいていること
-      assertThat(courseJava.getStudentId()).containsExactly(studentIdBytes);
-      assertThat(courseSql.getStudentId()).containsExactly(studentIdBytes);
-
-      // 3. 他の項目移送（ここではコース名だけ軽く確認）
-      assertThat(courseJava.getCourseName()).isEqualTo("Javaコース");
-      assertThat(courseSql.getCourseName()).isEqualTo("SQLコース");
+      assertThat(courseJava.getStudentId()).isEqualTo(studentId);
+      assertThat(courseSql.getStudentId()).isEqualTo(studentId);
     }
 
     /**
@@ -423,13 +292,13 @@ class StudentConverterTest {
 
       // 2つのコースDTO（どちらも CourseId が指定されている）
       StudentCourseDto dto1 = new StudentCourseDto(
-          FIXED_UUID_STRING,          // ★ 既存の CourseId（UUID）
+          UUID_STRING,          // ★ 既存の CourseId（UUID）
           "Javaコース",
           start,
           start.plusMonths(6)
       );
       StudentCourseDto dto2 = new StudentCourseDto(
-          FIXED_UUID_STRING_B,        // ★ 別の CourseId（UUID）
+          UUID_STRING_B,        // ★ 別の CourseId（UUID）
           "SQLコース",
           start,
           start.plusMonths(3)
@@ -438,13 +307,12 @@ class StudentConverterTest {
     }
 
     /**
-     * {@link StudentConverter#toEntityList(List, byte[])} において、 コース ID が未指定の DTO を渡した場合、新規 ID
-     * 採番が行われることを検証します。
+     * コース ID が未指定の DTO を渡した場合、新規 ID採番が行われることを検証します。
      */
     @Test
     void toEntityList_StudentCourseDto_CourseIDなし_StudentCourseが新規IDで生成されること() {
       // --- Given ---
-      byte[] studentIdBytes = FIXED_UUID_BYTES; // 紐付け先の受講生ID（UUIDの16バイト）
+      UUID studentId = UUID.fromString(UUID_STRING);
 
       LocalDate start = LocalDate.of(2025, 4, 1);
       LocalDate end = LocalDate.of(2025, 9, 30);
@@ -458,21 +326,18 @@ class StudentConverterTest {
       );
       List<StudentCourseDto> dtoList = List.of(dto);
 
-      // 新規 Course ID は IdCodec の generateNewIdBytes に委譲される
-      when(idCodec.generateNewIdBytes()).thenReturn(NEW_RANDOM_BYTES);
-
       // --- When ---
-      List<StudentCourse> result = converter.toEntityList(dtoList, studentIdBytes);
+      List<StudentCourse> result = converter.toEntityList(dtoList, studentId);
 
       // --- Then ---
       assertThat(result).hasSize(1);
       StudentCourse course = result.get(0);
 
-      // 1. 新しいIDがセットされていること
-      assertThat(course.getCourseId()).containsExactly(NEW_RANDOM_BYTES);
-      // 2. 渡した studentId がそのまま紐づいていること
-      assertThat(course.getStudentId()).containsExactly(studentIdBytes);
-      // 3. 他のフィールドの項目移送
+      // 1. 新しいIDが「ちゃんと採番されている」こと（null でない）
+      assertThat(course.getCourseId()).isNotNull();
+      // （必要なら「パラメータで渡した studentId がそのままセットされているか」も確認）
+      assertThat(course.getStudentId()).isEqualTo(studentId);
+      // 2. 他のフィールドの項目移送
       assertThat(course.getCourseName()).isEqualTo("Javaコース");
       assertThat(course.getStartDate()).isEqualTo(start);
       assertThat(course.getEndDate()).isEqualTo(end);
@@ -499,42 +364,42 @@ class StudentConverterTest {
 
         // --- Given (入力データの準備) ---
         LocalDate S = LocalDate.of(2025, 4, 1);
+
+        UUID studentIdA = uuid; // setUp で UUID_STRING から生成済み
+        UUID studentIdB = UUID.fromString(UUID_STRING_B);
+
         Student studentA = new Student(
-            FIXED_UUID_BYTES,
+            studentIdA,
             "山田 太郎", "ヤマダ タロウ", "Taro", "taro@example.com",
             "Tokyo", 25, "Male", "備考", null, null, null
         );
 
         // 2. 学生B (ID: FIXED_UUID_BYTES_B / UUID: FIXED_UUID_STRING_B)
         Student studentB = new Student(
-            FIXED_UUID_BYTES_B, "田中 花子", "タナカ ハナコ", "Hana",
+            studentIdB, "田中 花子", "タナカ ハナコ", "Hana",
             "hana@example.com", "Osaka", 30, "Female", "備考", null, null, null
         );
 
         // 3. コースA (学生Aに紐づくコース)
         StudentCourse courseA1 = new StudentCourse(
             // コースID自体の値は本テストの関心外なので、ゼロ埋め16バイトで十分
-            new byte[16], FIXED_UUID_BYTES, "Javaコース",
+            UUID.randomUUID(), studentIdA, "Javaコース",
             S, S.plusMonths(6), null
         );
 
         // 4. コースB (学生Bに紐づくコース)
         StudentCourse courseB1 = new StudentCourse(
-            new byte[16], FIXED_UUID_BYTES_B, "Pythonコース",
+            UUID.randomUUID(), studentIdB, "Pythonコース",
             S, S.plusMonths(3), null
         );
         StudentCourse courseB2 = new StudentCourse(
-            new byte[16], FIXED_UUID_BYTES_B, "SQLコース",
+            UUID.randomUUID(), studentIdB, "SQLコース",
             S, S.plusMonths(1), null
         );
 
         // 入力リストの作成
         List<Student> students = List.of(studentA, studentB);
         List<StudentCourse> courses = List.of(courseA1, courseB1, courseB2);
-
-        // 学生IDのUUID文字列化は IdCodec に委譲される
-        when(idCodec.encodeId(FIXED_UUID_BYTES)).thenReturn(FIXED_UUID_STRING);
-        when(idCodec.encodeId(FIXED_UUID_BYTES_B)).thenReturn(FIXED_UUID_STRING_B);
 
         // --- When (変換実行) ---
         List<StudentDetailDto> result =
@@ -548,14 +413,14 @@ class StudentConverterTest {
         StudentDetailDto dtoA = result.stream()
             .filter(d -> d.getStudent().getFullName().equals("山田 太郎"))
             .findFirst().orElseThrow();
-        assertThat(dtoA.getStudent().getStudentId()).isEqualTo(FIXED_UUID_STRING);
+        assertThat(dtoA.getStudent().getStudentId()).isEqualTo(UUID_STRING);
         assertThat(dtoA.getCourses()).hasSize(1); // Javaコースのみ
 
         // 3. 学生BのDTOを確認 (リストの2番目の要素と仮定)
         StudentDetailDto dtoB = result.stream()
             .filter(d -> d.getStudent().getFullName().equals("田中 花子"))
             .findFirst().orElseThrow();
-        assertThat(dtoB.getStudent().getStudentId()).isEqualTo(FIXED_UUID_STRING_B);
+        assertThat(dtoB.getStudent().getStudentId()).isEqualTo(UUID_STRING_B);
         assertThat(dtoB.getCourses()).hasSize(2); // PythonとSQLの2コース
 
         // 4. コース名が正しく含まれていることを確認（学生B）
@@ -575,30 +440,29 @@ class StudentConverterTest {
 
         // --- Given (入力データの準備) ---
         LocalDate S = LocalDate.of(2025, 4, 1);
+        UUID studentIdA = uuid; // setUp で UUID_STRING から生成済み
+        UUID studentIdB = UUID.fromString(UUID_STRING_B);
+
         Student studentA = new Student(
-            FIXED_UUID_BYTES,
+            studentIdA,
             "山田 太郎", "ヤマダ タロウ", "Taro", "taro@example.com",
             "Tokyo", 25, "Male", "備考", null, null, null
         );
         // 2. 学生B (ID: FIXED_UUID_BYTES_B / UUID: FIXED_UUID_STRING_B)
         Student studentB = new Student(
-            FIXED_UUID_BYTES_B, "田中 花子", "タナカ ハナコ", "Hana",
+            studentIdB, "田中 花子", "タナカ ハナコ", "Hana",
             "hana@example.com", "Osaka", 30, "Female", "備考", null, null, null
         );
         // 3. コースA (学生Aに紐づくコース)
         StudentCourse courseA1 = new StudentCourse(
-            new byte[16], FIXED_UUID_BYTES, "Javaコース",
+            UUID.randomUUID(),             // courseId 適当でOK
+            studentIdA, "Javaコース",
             S, S.plusMonths(6), null
         );
 
         // 入力リストの作成
         List<Student> students = List.of(studentA, studentB);
         List<StudentCourse> courses = List.of(courseA1); // コースA1のみ
-
-        when(idCodec.encodeId(any())).thenReturn("IGNORED"); // コースIDなど、テストの関心外
-        // そのうえで、「学生ID」だけは上書きして本物の期待値を返す
-        when(idCodec.encodeId(FIXED_UUID_BYTES)).thenReturn(FIXED_UUID_STRING);
-        when(idCodec.encodeId(FIXED_UUID_BYTES_B)).thenReturn(FIXED_UUID_STRING_B);
 
         // --- When (変換実行) ---
         List<StudentDetailDto> result =
@@ -612,14 +476,14 @@ class StudentConverterTest {
         StudentDetailDto dtoA = result.stream()
             .filter(d -> d.getStudent().getFullName().equals("山田 太郎"))
             .findFirst().orElseThrow();
-        assertThat(dtoA.getStudent().getStudentId()).isEqualTo(FIXED_UUID_STRING);
+        assertThat(dtoA.getStudent().getStudentId()).isEqualTo(UUID_STRING);
         assertThat(dtoA.getCourses()).hasSize(1); // Javaコースのみ
 
         // 3. 学生BのDTOを確認 (リストの2番目の要素と仮定)
         StudentDetailDto dtoB = result.stream()
             .filter(d -> d.getStudent().getFullName().equals("田中 花子"))
             .findFirst().orElseThrow();
-        assertThat(dtoB.getStudent().getStudentId()).isEqualTo(FIXED_UUID_STRING_B);
+        assertThat(dtoB.getStudent().getStudentId()).isEqualTo(UUID_STRING_B);
         assertThat(dtoB.getCourses()).isEmpty();
       }
 
@@ -632,7 +496,7 @@ class StudentConverterTest {
         // mergeStudent(Student existing, Student update) のテスト
         // 既存のデータ（DBから取得した想定）
         Student existing = new Student(
-            FIXED_UUID_BYTES,
+            uuid,
             "山田 太郎", "ヤマダ タロウ", "Taro", "taro@example.com",
             "Tokyo", 25, "Male", "元の備考", null, null, null
         );

--- a/src/test/java/raisetech/student/management/repository/StudentCourseRepositoryTest.java
+++ b/src/test/java/raisetech/student/management/repository/StudentCourseRepositoryTest.java
@@ -1,0 +1,222 @@
+package raisetech.student.management.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import raisetech.student.management.data.Student;
+import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.util.UUIDUtil;
+
+@MybatisTest
+public class StudentCourseRepositoryTest {
+
+  @Autowired
+  StudentCourseRepository sut;
+
+  @Autowired
+  StudentRepository studentRepository; // FK用に受講生も1人作る
+
+  /**
+   * テスト用の受講生を1件INSERTし、そのstudent_id(byte[16])を返すヘルパー。
+   */
+  private byte[] insertTestStudentAndReturnId() {
+    byte[] id = UUIDUtil.fromUUID(UUID.randomUUID());
+
+    Student s = new Student();
+    s.setStudentId(id);
+    s.setFullName("テスト 受講生");
+    s.setFurigana("てすと じゅこうせい");
+    s.setNickname("テスト");
+    s.setEmail("course-" + System.nanoTime() + "@example.com");
+    s.setLocation("Osaka");
+    s.setAge(20);
+    s.setGender("Male");
+    s.setRemarks("コーステスト用");
+    s.setDeleted(false);
+
+    studentRepository.insertStudent(s);
+    return id;
+  }
+
+  /**
+   * テスト用の StudentCourse を1件生成する共通ヘルパー（フル版）
+   */
+  private StudentCourse newCourse(byte[] studentId, String courseName,
+      LocalDate start, LocalDate end) {
+    StudentCourse c = new StudentCourse();
+    c.setCourseId(UUIDUtil.fromUUID(UUID.randomUUID()));
+    c.setStudentId(studentId);
+    c.setCourseName(courseName);
+    c.setStartDate(start);   // ★ここが今回のポイント
+    c.setEndDate(end);       // endDate が NOT NULL なら必須
+    return c;
+  }
+
+  // よく使う「お任せ」版（今回のテストではこっちを使う）
+  private StudentCourse newCourse(byte[] studentId, String courseName) {
+    return newCourse(
+        studentId,
+        courseName,
+        LocalDate.of(2025, 1, 1),
+        LocalDate.of(2025, 12, 31)
+    );
+  }
+
+  @Test
+  void findAllCourses_全件取得できること() {
+    List<StudentCourse> actual = sut.findAllCourses();
+
+    assertThat(actual)
+        .isNotNull()
+        .hasSize(21);
+  }
+
+  @Test
+  void findCoursesByStudentId_特定受講生のコースのみ取得できること() {
+    byte[] studentId1 = insertTestStudentAndReturnId();
+    byte[] studentId2 = insertTestStudentAndReturnId();
+
+    // ★ コースエンティティを作成（2引数版でOK）
+    StudentCourse c1 = newCourse(studentId1, "Javaコース");
+    StudentCourse c2 = newCourse(studentId1, "AWSコース");
+    StudentCourse c3 = newCourse(studentId2, "Pythonコース");
+
+    // ★ 実際に DB に INSERT しないと、find しても出てこないので注意！
+    sut.insertCourses(List.of(c1, c2, c3));
+
+    List<StudentCourse> actual = sut.findCoursesByStudentId(studentId1);
+
+    assertThat(actual)
+        .hasSize(2)
+        .extracting(StudentCourse::getCourseName)
+        .containsExactlyInAnyOrder("Javaコース", "AWSコース");
+  }
+
+  @Test
+  void insertCourses_複数コースを一括登録できること() {
+    byte[] studentId = insertTestStudentAndReturnId();
+
+    StudentCourse c1 = newCourse(
+        studentId,
+        "Javaコース",
+        LocalDate.of(2025, 1, 1),
+        LocalDate.of(2025, 3, 31)
+    );
+
+    StudentCourse c2 = newCourse(
+        studentId,
+        "AWSコース",
+        LocalDate.of(2025, 4, 1),
+        LocalDate.of(2025, 6, 30)
+    );
+
+    sut.insertCourses(List.of(c1, c2));
+
+    // Assert: studentId に紐づくコースが2件増えていることなどを確認
+    List<StudentCourse> actual = sut.findCoursesByStudentId(studentId);
+    // 事前件数を取ってないなら「2件存在すること」でもOK
+    assertThat(actual).hasSize(2);
+  }
+
+  @Test
+  void insertCourses_存在しない受講生IDを指定した場合はDataIntegrityViolationException() {
+    byte[] nonExistingStudentId = UUIDUtil.fromUUID(UUID.randomUUID());
+
+    // NOT NULL をすべて満たした上で FK だけ不正にする
+    StudentCourse c = newCourse(
+        nonExistingStudentId,
+        "不正コース",
+        LocalDate.of(2025, 1, 1),
+        LocalDate.of(2025, 12, 31)
+    );
+
+    assertThatThrownBy(() -> sut.insertCourses(List.of(c)))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void insertIfNotExists_存在しない組み合わせなら登録されること() {
+    byte[] studentId = insertTestStudentAndReturnId();
+
+    StudentCourse course = newCourse(
+        studentId,
+        "Javaコース",
+        LocalDate.of(2025, 1, 1),
+        LocalDate.of(2025, 3, 31)
+    );
+
+    sut.insertIfNotExists(course);
+
+    List<StudentCourse> actual = sut.findCoursesByStudentId(studentId);
+    assertThat(actual)
+        .singleElement() // 要素がちょうど1件であることも同時に検証
+        .extracting(StudentCourse::getCourseName)
+        .isEqualTo("Javaコース");
+  }
+
+  @Test
+  void insertIfNotExists_同一受講生同一コース名は2回目以降挿入されないこと() {
+    byte[] studentId = insertTestStudentAndReturnId();
+
+    StudentCourse course = newCourse(
+        studentId,
+        "Javaコース",
+        LocalDate.of(2025, 1, 1),
+        LocalDate.of(2025, 3, 31)
+    );
+
+    // 1回目: INSERTされる
+    sut.insertIfNotExists(course);
+
+    // 2回目: 同じ studentId + courseName はINSERTされない（0件追加のイメージ）
+    sut.insertIfNotExists(course); // ここは挿入されないはず
+
+    List<StudentCourse> actual = sut.findCoursesByStudentId(studentId);
+    assertThat(actual)
+        .singleElement() // 要素がちょうど1件であることも同時に検証
+        .extracting(StudentCourse::getCourseName)
+        .isEqualTo("Javaコース");
+  }
+
+  @Test
+  void deleteCoursesByStudentId_紐づくコースが全て削除されること() {
+    byte[] studentId = insertTestStudentAndReturnId();
+
+    StudentCourse c1 = newCourse(studentId, "Java基礎");
+    StudentCourse c2 = newCourse(studentId, "AWS入門");
+
+    // 実際にINSERT
+    sut.insertCourses(List.of(c1, c2));
+
+    // 削除前に2件あることを確認
+    assertThat(sut.findCoursesByStudentId(studentId)).hasSize(2);
+
+    // 削除実行
+    sut.deleteCoursesByStudentId(studentId);
+
+    // 削除後は0件になっていること
+    assertThat(sut.findCoursesByStudentId(studentId)).isEmpty();
+  }
+
+  @Test
+  void deleteCoursesByStudentId_該当コースが無いIDでも例外にならないこと() {
+    byte[] nonExistingStudentId = UUIDUtil.fromUUID(UUID.randomUUID());
+
+    int beforeSize = sut.findAllCourses().size();
+
+    // 例外が出ないことだけ確認
+    sut.deleteCoursesByStudentId(nonExistingStudentId);
+
+    // 念のためテーブル全体件数が変わっていないか確認してもOK
+    int afterSize = sut.findAllCourses().size();
+    assertThat(afterSize).isEqualTo(beforeSize);
+  }
+}
+

--- a/src/test/java/raisetech/student/management/repository/StudentCourseRepositoryTest.java
+++ b/src/test/java/raisetech/student/management/repository/StudentCourseRepositoryTest.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
-import raisetech.student.management.util.UUIDUtil;
 
 @MybatisTest
 public class StudentCourseRepositoryTest {
@@ -26,8 +25,8 @@ public class StudentCourseRepositoryTest {
   /**
    * テスト用の受講生を1件INSERTし、そのstudent_id(byte[16])を返すヘルパー。
    */
-  private byte[] insertTestStudentAndReturnId() {
-    byte[] id = UUIDUtil.toBytes(UUID.randomUUID());
+  private UUID insertTestStudentAndReturnId() {
+    UUID id = UUID.randomUUID();
 
     Student s = new Student();
     s.setStudentId(id);
@@ -48,10 +47,10 @@ public class StudentCourseRepositoryTest {
   /**
    * テスト用の StudentCourse を1件生成する共通ヘルパー（フル版）
    */
-  private StudentCourse newCourse(byte[] studentId, String courseName,
+  private StudentCourse newCourse(UUID studentId, String courseName,
       LocalDate start, LocalDate end) {
     StudentCourse c = new StudentCourse();
-    c.setCourseId(UUIDUtil.toBytes(UUID.randomUUID()));
+    c.setCourseId(UUID.randomUUID());
     c.setStudentId(studentId);
     c.setCourseName(courseName);
     c.setStartDate(start);   // ★ここが今回のポイント
@@ -60,7 +59,7 @@ public class StudentCourseRepositoryTest {
   }
 
   // よく使う「お任せ」版（今回のテストではこっちを使う）
-  private StudentCourse newCourse(byte[] studentId, String courseName) {
+  private StudentCourse newCourse(UUID studentId, String courseName) {
     return newCourse(
         studentId,
         courseName,
@@ -80,8 +79,8 @@ public class StudentCourseRepositoryTest {
 
   @Test
   void findCoursesByStudentId_特定受講生のコースのみ取得できること() {
-    byte[] studentId1 = insertTestStudentAndReturnId();
-    byte[] studentId2 = insertTestStudentAndReturnId();
+    UUID studentId1 = insertTestStudentAndReturnId();
+    UUID studentId2 = insertTestStudentAndReturnId();
 
     // ★ コースエンティティを作成（2引数版でOK）
     StudentCourse c1 = newCourse(studentId1, "Javaコース");
@@ -101,7 +100,7 @@ public class StudentCourseRepositoryTest {
 
   @Test
   void insertCourses_複数コースを一括登録できること() {
-    byte[] studentId = insertTestStudentAndReturnId();
+    UUID studentId = insertTestStudentAndReturnId();
 
     StudentCourse c1 = newCourse(
         studentId,
@@ -127,7 +126,7 @@ public class StudentCourseRepositoryTest {
 
   @Test
   void insertCourses_存在しない受講生IDを指定した場合はDataIntegrityViolationException() {
-    byte[] nonExistingStudentId = UUIDUtil.toBytes(UUID.randomUUID());
+    UUID nonExistingStudentId = UUID.randomUUID();
 
     // NOT NULL をすべて満たした上で FK だけ不正にする
     StudentCourse c = newCourse(
@@ -143,7 +142,7 @@ public class StudentCourseRepositoryTest {
 
   @Test
   void insertIfNotExists_存在しない組み合わせなら登録されること() {
-    byte[] studentId = insertTestStudentAndReturnId();
+    UUID studentId = insertTestStudentAndReturnId();
 
     StudentCourse course = newCourse(
         studentId,
@@ -163,7 +162,7 @@ public class StudentCourseRepositoryTest {
 
   @Test
   void insertIfNotExists_同一受講生同一コース名は2回目以降挿入されないこと() {
-    byte[] studentId = insertTestStudentAndReturnId();
+    UUID studentId = insertTestStudentAndReturnId();
 
     StudentCourse course = newCourse(
         studentId,
@@ -187,7 +186,7 @@ public class StudentCourseRepositoryTest {
 
   @Test
   void deleteCoursesByStudentId_紐づくコースが全て削除されること() {
-    byte[] studentId = insertTestStudentAndReturnId();
+    UUID studentId = insertTestStudentAndReturnId();
 
     StudentCourse c1 = newCourse(studentId, "Java基礎");
     StudentCourse c2 = newCourse(studentId, "AWS入門");
@@ -207,7 +206,7 @@ public class StudentCourseRepositoryTest {
 
   @Test
   void deleteCoursesByStudentId_該当コースが無いIDでも例外にならないこと() {
-    byte[] nonExistingStudentId = UUIDUtil.toBytes(UUID.randomUUID());
+    UUID nonExistingStudentId = UUID.randomUUID();
 
     int beforeSize = sut.findAllCourses().size();
 

--- a/src/test/java/raisetech/student/management/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/student/management/repository/StudentRepositoryTest.java
@@ -1,0 +1,304 @@
+package raisetech.student.management.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import raisetech.student.management.data.Student;
+import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.util.UUIDUtil;
+
+@MybatisTest
+public class StudentRepositoryTest {
+
+  @Autowired
+  private StudentRepository sut;
+
+  @Autowired
+  private StudentCourseRepository courseRepository;
+
+  // コア：すべてのフィールドを引数で受け取る（private）
+  private byte[] insertStudent(
+      String fullName,
+      String furigana,
+      String nickname,
+      String email,
+      String location,
+      int age,
+      String gender,
+      String remarks
+  ) {
+    byte[] id = UUIDUtil.fromUUID(UUID.randomUUID());
+
+    Student s = new Student();
+    s.setStudentId(id);
+    s.setFullName(fullName);
+    s.setFurigana(furigana);
+    s.setNickname(nickname);
+    s.setEmail(email);
+    s.setLocation(location);
+    s.setAge(age);
+    s.setGender(gender);
+    s.setRemarks(remarks);
+    s.setDeleted(false);
+
+    sut.insertStudent(s);
+    return id;
+  }
+
+  // 一般用：何も考えずに「まともな1件」が欲しいとき
+  private byte[] insertTestStudentAndReturnId() {
+    String email = "test-" + System.nanoTime() + "@example.com";
+    return insertStudent(
+        "テスト 太郎",
+        "てすと たろう",
+        "テスト",
+        email,
+        "東京",
+        20,
+        "male",
+        "テスト用"
+    );
+  }
+
+  // email を指定したいときだけこれを使う
+  private byte[] insertTestStudentAndReturnId(String email) {
+    return insertStudent(
+        "テスト 一郎",
+        "てすと いちろう",
+        "いっくん",
+        email,
+        "Nagoya",
+        20,
+        "Male",
+        "テスト用レコード"
+    );
+  }
+
+  @Test
+  void searchStudents_受講生の全件検索が行えること() {
+    List<Student> actual = sut.searchStudents(
+        null,   // furigana 検索条件なし
+        true,   // includeDeleted: 論理削除済みも含める
+        false   // deletedOnly: 削除済みのみではない
+    );
+    // 検証
+    assertThat(actual).hasSize(16);
+  }
+
+  @Test
+  void searchStudents_論理削除を除いた受講生一覧が取得できること() {
+    List<Student> actual = sut.searchStudents(
+        null,
+        false, // includeDeleted: 削除済みは含めない
+        false  // deletedOnly: 削除済みのみではない
+    );
+
+    assertThat(actual).hasSize(14); // 16件中、2件が is_deleted = 1 の想定
+  }
+
+  @Test
+  void searchStudents_論理削除された受講生のみ取得できること() {
+    List<Student> actual = sut.searchStudents(
+        null,
+        true,  // ※ 全件＋下の deletedOnly 条件で削除のみになるはず
+        true   // deletedOnly: 削除済みのみ
+    );
+
+    assertThat(actual).hasSize(2);
+  }
+
+  @Test
+  void searchStudents_ふりがなで部分一致検索が行えること() {
+    List<Student> actual = sut.searchStudents(
+        "やまだ", // data.sql 上のふりがなに合わせて
+        true,     // 削除も含める
+        false
+    );
+
+    assertThat(actual)
+        .singleElement()
+        .extracting(Student::getFullName)
+        .isEqualTo("Yamada Taro");
+  }
+
+  @Test
+  void insertStudent_受講生の登録が行えること() {
+    // arrange: INSERT前の件数を取得
+    List<Student> before = sut.searchStudents(null, true, false);
+    int beforeSize = before.size();
+
+    // act: 1件INSERT
+    byte[] id = insertTestStudentAndReturnId();
+
+    // assert: 件数が +1 されていること
+    List<Student> after = sut.searchStudents(null, true, false);
+    assertThat(after.size()).isEqualTo(beforeSize + 1);
+
+    // さきほどのIDを持つレコードが存在すること
+    Student saved = after.stream()
+        .filter(s -> Arrays.equals(s.getStudentId(), id))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("登録した受講生が見つかりません"));
+
+    // ついでに中身も確認しておく
+    assertThat(saved.getDeleted()).isFalse();
+  }
+
+
+  @Test
+  void findById_既存IDで取得できること() {
+    byte[] id = insertTestStudentAndReturnId(); // ← 引数なし版でOK
+
+    Student found = sut.findById(id);
+
+    assertThat(found).isNotNull();
+    assertThat(found.getStudentId()).isEqualTo(id);
+  }
+
+
+  @Test
+  void findById_存在しないIDの場合はnullが返ること() {
+    UUID unused = UUID.randomUUID();
+    byte[] unusedId = UUIDUtil.fromUUID(unused);
+
+    Student actual = sut.findById(unusedId);
+
+    assertThat(actual).isNull();
+  }
+
+  @Test
+  void updateStudent_既存受講生の情報を更新できること() {
+    // まずテスト用レコードをINSERTして、そのIDをもらう
+    byte[] id = insertTestStudentAndReturnId();
+
+    Student student = sut.findById(id);
+    assertThat(student).isNotNull();
+
+    student.setStudentId(id);
+    student.setFullName("更新 一郎");
+    student.setFurigana("こうしん いちろう");
+    student.setRemarks("更新済みレコード");
+
+    int updated = sut.updateStudent(student);
+    assertThat(updated).isEqualTo(1);
+
+    // Assert
+    Student reloaded = sut.findById(id);
+    assertThat(reloaded.getFullName()).isEqualTo("更新 一郎");
+    assertThat(reloaded.getFurigana()).isEqualTo("こうしん いちろう");
+    assertThat(reloaded.getRemarks()).isEqualTo("更新済みレコード");
+  }
+
+  @Test
+  void updateStudent_必須項目がnullの場合はDataIntegrityViolationExceptionが送出されること() {
+    byte[] id = insertTestStudentAndReturnId();
+
+    // そのレコードを取得
+    Student toUpdate = sut.findById(id);
+    assertThat(toUpdate).isNotNull();
+
+    // full_name を null にして NOT NULL 制約違反を起こさせる
+    toUpdate.setFullName(null);
+
+    // update 時に DataIntegrityViolationException が投げられること
+    assertThatThrownBy(() -> sut.updateStudent(toUpdate))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void updateStudent_存在しないIDの場合は0件更新となること() {
+    // 未使用っぽい ID を生成
+    byte[] unusedId = UUIDUtil.fromUUID(UUID.randomUUID());
+
+    Student student = new Student();
+    student.setStudentId(unusedId);
+    student.setFullName("ダミー");
+    student.setFurigana("だみー");
+    student.setEmail("dummy@example.com");
+    student.setGender("Male");
+    student.setLocation("どこか");
+    student.setAge(30);
+
+    int updated = sut.updateStudent(student);
+
+    assertThat(updated).isEqualTo(0);
+  }
+
+  @Test
+  void updateStudent_メールアドレスが重複するとDataIntegrityViolationExceptionになること() {
+    // 重複させたいメールアドレス
+    String duplicatedEmail = "dup-update@example.com";
+
+    // 1人目 INSERT（data.sql の既存レコードでもOK）
+    byte[] id1 = insertTestStudentAndReturnId(duplicatedEmail);
+
+    // 2人目 INSERT
+    byte[] id2 = insertTestStudentAndReturnId("second-update@example.com"); // メールは別のものにしておく
+    Student student2 = sut.findById(id2);
+    assertThat(student2).isNotNull();
+
+    // 2人目の email を 1人目と同じにしてユニーク制約違反を起こさせる
+    student2.setEmail(duplicatedEmail); // id1 と同じにするイメージ
+
+    assertThatThrownBy(() -> sut.updateStudent(student2))
+        .isInstanceOf(DataIntegrityViolationException.class); // or DuplicateKeyException
+  }
+
+  @Test
+  void updateStudent_年齢が負の値の場合はDataIntegrityViolationExceptionになること() {
+    byte[] id = insertTestStudentAndReturnId();
+    Student student = sut.findById(id);
+    assertThat(student).isNotNull();
+
+    student.setAge(-1);
+
+    assertThatThrownBy(() -> sut.updateStudent(student))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void forceDeleteStudent_受講生が存在する場合は削除されること() {
+    byte[] id = insertTestStudentAndReturnId();
+
+    int deleted = sut.forceDeleteStudent(id);
+
+    assertThat(deleted).isEqualTo(1);
+    assertThat(sut.findById(id)).isNull();
+  }
+
+  @Test
+  void forceDeleteStudent_存在しないIDの場合は0件削除となること() {
+    byte[] unusedId = UUIDUtil.fromUUID(UUID.randomUUID());
+
+    int deleted = sut.forceDeleteStudent(unusedId);
+
+    assertThat(deleted).isEqualTo(0);
+  }
+
+  @Test
+  void forceDeleteStudent_受講コースが残っている場合は外部キー制約違反で例外になること() {
+    byte[] id = insertTestStudentAndReturnId();
+
+    StudentCourse course = new StudentCourse();
+    course.setStudentId(id);
+    course.setCourseId(UUIDUtil.fromUUID(UUID.randomUUID()));
+    course.setCourseName("Javaコース");
+    course.setStartDate(LocalDate.of(2025, 1, 1));
+    course.setEndDate(LocalDate.of(2025, 12, 31));
+    // 他の必須項目があればセット
+
+    courseRepository.insertCourses(List.of(course));
+
+    // Act & Assert: 子が残った状態で親だけ消そうとすると FK エラー
+    assertThatThrownBy(() -> sut.forceDeleteStudent(id))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+}

--- a/src/test/java/raisetech/student/management/service/StudentServiceImplTest.java
+++ b/src/test/java/raisetech/student/management/service/StudentServiceImplTest.java
@@ -30,13 +30,12 @@ import raisetech.student.management.dto.StudentDetailDto;
 import raisetech.student.management.exception.ResourceNotFoundException;
 import raisetech.student.management.repository.StudentCourseRepository;
 import raisetech.student.management.repository.StudentRepository;
-import raisetech.student.management.util.UUIDUtil;
 
 /**
  * {@link StudentServiceImpl} の単体テストクラス。
  *
- * <p>UUID を byte[16]（BINARY(16)）として扱うドメイン設計を前提に、
- * 受講生情報およびコース情報に対するサービス層の振る舞いを検証します。
+ * <p>DB では UUID を BINARY(16) で保持しつつ、
+ * サービス層では UUID 型として受講生情報およびコース情報を扱う前提で、 その振る舞いを検証します。
  *
  * <ul>
  *   <li>リポジトリ層への委譲が正しく行われているか</li>
@@ -81,17 +80,14 @@ class StudentServiceImplTest {
   private StudentServiceImpl service;
 
   /**
-   * テストで利用する固定 UUID 文字列表現。
-   *
-   * <p>この値を {@link UUIDUtil#toBytes(UUID)} で byte[16] に変換して
-   * {@code studentId} として利用します。
+   * テストで利用する固定 UUID。
    */
   private static final String UUID_STRING = "123e4567-e89b-12d3-a456-426614174000";
 
   /**
-   * テスト共通で使用する受講生 ID（UUID を BINARY(16) にした 16バイト配列）。
+   * テスト共通で使用する受講生 ID（UUID）。
    */
-  private byte[] studentId;
+  private UUID studentId;
 
   /**
    * テスト共通で使用する受講生エンティティ。
@@ -116,8 +112,7 @@ class StudentServiceImplTest {
    */
   @BeforeEach
   void setUp() {
-    // UUID文字列 → UUID → byte[16]
-    studentId = UUIDUtil.toBytes(UUID.fromString(UUID_STRING));
+    studentId = UUID.fromString(UUID_STRING);
 
     student = new Student();
     student.setStudentId(studentId);
@@ -130,7 +125,7 @@ class StudentServiceImplTest {
     // コースを1件追加してcoursesを初期化（必要に応じて各テスト内で利用）
     StudentCourse course = new StudentCourse();
     course.setStudentId(studentId);
-    course.setCourseId(new byte[16]); // 任意のダミーUUID（16バイト）
+    course.setCourseId(UUID.randomUUID()); // 任意のダミーUUID
   }
 
   /**
@@ -172,7 +167,7 @@ class StudentServiceImplTest {
     // updateStudent用のオブジェクトを準備
     StudentCourse course = new StudentCourse();
     course.setStudentId(student.getStudentId());
-    course.setCourseId(new byte[16]); // 仮のCourse ID
+    course.setCourseId(UUID.randomUUID()); // 仮のCourse ID
 
     List<StudentCourse> courses = List.of(course);
 
@@ -201,8 +196,10 @@ class StudentServiceImplTest {
    */
   @Test
   void updateStudent_存在しないIDならResourceNotFoundExceptionが送出されること() {
+    Student s = new Student();
+    s.setStudentId(studentId);
+
     when(studentRepository.updateStudent(student)).thenReturn(0);
-    when(converter.encodeUuidString(studentId)).thenReturn(UUID_STRING);
 
     assertThatThrownBy(() -> service.updateStudent(student, List.of()))
         .isInstanceOf(ResourceNotFoundException.class)
@@ -228,7 +225,7 @@ class StudentServiceImplTest {
     student.setFullName("検証 太郎");
 
     StudentCourse course = new StudentCourse();
-    course.setCourseId(new byte[16]);
+    course.setCourseId(UUID.randomUUID());
     List<StudentCourse> courses = List.of(course);
 
     // ★件数 1 を返すようにスタブ
@@ -247,16 +244,14 @@ class StudentServiceImplTest {
   }
 
   /**
-   * partialUpdateStudent 実行時に、studentId が UUID として不正な長さ（16バイト以外）の場合、 処理を行わずに
-   * IllegalArgumentException を送出することを検証します。
+   * partialUpdateStudent 実行時に、studentId が null の場合、 処理を行わずに IllegalArgumentException
+   * を送出することを検証します。
    *
-   * <p>サービス層で ID フォーマットを早期にチェックすることで、
-   * 不正な ID によるリポジトリ呼び出しを防ぎます。
+   * <p>サービス層で ID の null を早期に検出し、不正な呼び出しを防ぎます。
    */
   @Test
-  void partialUpdateStudent_studentIdが16バイト以外ならIllegalArgumentException() {
+  void partialUpdateStudent_studentIdがnullならIllegalArgumentException() {
     Student s = new Student();
-    s.setStudentId(new byte[8]); // 不正な長さ
 
     assertThatThrownBy(() -> service.partialUpdateStudent(s, List.of()))
         .isInstanceOf(IllegalArgumentException.class)
@@ -275,7 +270,7 @@ class StudentServiceImplTest {
     // appendCourses用のオブジェクトを準備
     StudentCourse course = new StudentCourse();
     course.setStudentId(student.getStudentId());
-    course.setCourseId(new byte[16]);
+    course.setCourseId(UUID.randomUUID());
 
     List<StudentCourse> newCourses = List.of(course);
 
@@ -296,7 +291,7 @@ class StudentServiceImplTest {
 
     // 準備
     Student student = new Student();
-    student.setStudentId(new byte[16]);
+    student.setStudentId(studentId);
     student.setFullName("検証　テスト");
 
     // ★件数 1 を返す
@@ -322,7 +317,6 @@ class StudentServiceImplTest {
     s.setStudentId(studentId);
 
     when(studentRepository.updateStudent(s)).thenReturn(0);
-    when(converter.encodeUuidString(studentId)).thenReturn(UUID_STRING);
 
     assertThatThrownBy(() -> service.updateStudentInfoOnly(s))
         .isInstanceOf(ResourceNotFoundException.class)
@@ -486,7 +480,6 @@ class StudentServiceImplTest {
 
     // 準備（モックの設定）
     when(studentRepository.findById(studentId)).thenReturn(null);
-    when(converter.encodeUuidString(studentId)).thenReturn(UUID_STRING);
 
     // 実行
     assertThatThrownBy(() -> service.findStudentById(studentId))
@@ -496,10 +489,10 @@ class StudentServiceImplTest {
   }
 
   /**
-   * searchCoursesByStudentId で、受講生 ID に紐づくコース一覧が取得できることを検証します。
+   * {@link StudentServiceImpl#searchCoursesByStudentId(UUID)} で、 受講生IDに紐づくコース一覧が取得できることを検証します。
    *
-   * <p>{@link StudentCourseRepository#findCoursesByStudentId(byte[])} の委譲と
-   * 戻り値のそのまま返却を確認します。
+   * <p>{@link StudentCourseRepository#findCoursesByStudentId(UUID)} への委譲と、
+   * リポジトリの戻り値をそのまま返却していることを確認します。
    */
   @Test
   void searchCoursesByStudentId_受講生IDで検索_紐づくコース情報を取得できること() {
@@ -507,13 +500,13 @@ class StudentServiceImplTest {
     // 準備
     StudentCourse course1 = new StudentCourse();
     course1.setStudentId(studentId);
-    course1.setCourseId(UUIDUtil.toBytes(
-        UUID.fromString("123e4567-e89b-12d3-a456-426614174001"))); // 仮のCourse ID 1
+    course1.setCourseId(
+        UUID.fromString("123e4567-e89b-12d3-a456-426614174001")); // 仮のCourse ID 1
 
     StudentCourse course2 = new StudentCourse();
     course2.setStudentId(studentId);
-    course2.setCourseId(UUIDUtil.toBytes(
-        UUID.fromString("123e4567-e89b-12d3-a456-426614174001"))); // 仮のCourse ID 2
+    course2.setCourseId(
+        UUID.fromString("123e4567-e89b-12d3-a456-426614174002")); // 仮のCourse ID 2
 
     List<StudentCourse> expectedCourses = List.of(course1, course2);
 
@@ -538,11 +531,11 @@ class StudentServiceImplTest {
 
     // 準備
     StudentCourse course1 = new StudentCourse();
-    course1.setCourseId(UUIDUtil.toBytes(UUID.fromString("123e4567-e89b-12d3-a456-426614174003")));
+    course1.setCourseId(UUID.fromString("123e4567-e89b-12d3-a456-426614174003"));
     course1.setCourseName("Javaコース");
 
     StudentCourse course2 = new StudentCourse();
-    course2.setCourseId(UUIDUtil.toBytes(UUID.fromString("123e4567-e89b-12d3-a456-426614174003")));
+    course2.setCourseId(UUID.fromString("123e4567-e89b-12d3-a456-426614174003"));
     course2.setCourseName("AWSコース");
 
     List<StudentCourse> mockCourses = List.of(course1, course2);
@@ -566,7 +559,6 @@ class StudentServiceImplTest {
 
     // モックの設定
     when(studentRepository.findById(studentId)).thenReturn(null);
-    when(converter.encodeUuidString(studentId)).thenReturn(UUID_STRING);
 
     // 実行
     assertThatThrownBy(() -> spyService.softDeleteStudent(studentId))
@@ -611,7 +603,6 @@ class StudentServiceImplTest {
 
     // モックの設定
     when(studentRepository.findById(studentId)).thenReturn(null);
-    when(converter.encodeUuidString(studentId)).thenReturn(UUID_STRING);
 
     // 実行
     Throwable thrown = catchThrowable(() -> service.restoreStudent(studentId));
@@ -630,8 +621,6 @@ class StudentServiceImplTest {
 
     when(student.getDeleted()).thenReturn(true);
     when(studentRepository.findById(studentId)).thenReturn(student);
-    when(converter.encodeUuidString(studentId)).thenReturn(UUID_STRING);
-
     when(studentRepository.updateStudent(student)).thenReturn(1);
 
     service.restoreStudent(studentId);
@@ -649,7 +638,6 @@ class StudentServiceImplTest {
 
     when(student.getDeleted()).thenReturn(false);
     when(studentRepository.findById(studentId)).thenReturn(student);
-    when(converter.encodeUuidString(studentId)).thenReturn(UUID_STRING);
 
     service.restoreStudent(studentId);
 
@@ -667,7 +655,6 @@ class StudentServiceImplTest {
   void forceDeleteStudent_該当の受講生が存在しない時は例外がスローされること() {
     // モックの設定
     when(studentRepository.forceDeleteStudent(studentId)).thenReturn(0);
-    when(converter.encodeUuidString(studentId)).thenReturn(UUID_STRING);
 
     // 実行＆検証
     assertThatThrownBy(() -> service.forceDeleteStudent(studentId))
@@ -691,7 +678,6 @@ class StudentServiceImplTest {
   void forceDeleteStudent_受講生が存在する場合はコースと受講生情報が削除されること() {
     // モックの準備
     when(studentRepository.forceDeleteStudent(studentId)).thenReturn(1);
-    when(converter.encodeUuidString(studentId)).thenReturn(UUID_STRING);
 
     // 実行
     service.forceDeleteStudent(studentId);

--- a/src/test/java/raisetech/student/management/util/StudentIdCodecTest.java
+++ b/src/test/java/raisetech/student/management/util/StudentIdCodecTest.java
@@ -3,7 +3,6 @@ package raisetech.student.management.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.nio.ByteBuffer;
 import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,29 +28,13 @@ public class StudentIdCodecTest {
    * <p>UUID 自体の値はテストの関心事ではなく、再現性のある固定値であればよい前提です。
    */
   private final UUID FIXED_UUID = UUID.fromString("12345678-9abc-def0-1234-56789abcdef0");
-
-  /**
-   * UUID を 16 バイトの配列（BINARY(16)）に変換するテスト用ユーティリティです。
-   *
-   * <p>本番コード側でも、UUID を {@code BINARY(16)} に変換するユーティリティ
-   * （例: {@code UUIDUtil#fromUUID(UUID)} 等）が同じ変換を担うことを想定しています。
-   *
-   * @param uuid 変換対象の UUID
-   * @return 引数の UUID を表現する 16 バイト配列
-   */
-  private static byte[] toBytes(UUID uuid) {
-    ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
-    bb.putLong(uuid.getMostSignificantBits());
-    bb.putLong(uuid.getLeastSignificantBits());
-    return bb.array();
-  }
-
+  
   /**
    * FIXED_UUID を BINARY(16) に変換したもの（UUID の生 16 バイト表現）。
    *
    * <p>encode／decode の結果検証に利用します。
    */
-  private final byte[] FIXED_UUID_BYTES = toBytes(FIXED_UUID);
+  private final byte[] FIXED_UUID_BYTES = UUIDUtil.fromUUID(FIXED_UUID);
 
   /**
    * FIXED_UUID の標準的な UUID 文字列表現。
@@ -182,8 +165,9 @@ public class StudentIdCodecTest {
     void generateNewIdBytes_正常系_16バイト長の配列が返されること() {
       byte[] idBytes = codec.generateNewIdBytes();
 
-      assertThat(idBytes).isNotNull();
-      assertThat(idBytes).hasSize(16);
+      assertThat(idBytes)
+          .isNotNull()
+          .hasSize(16);
     }
   }
 

--- a/src/test/java/raisetech/student/management/util/UUIDUtilTest.java
+++ b/src/test/java/raisetech/student/management/util/UUIDUtilTest.java
@@ -39,9 +39,17 @@ public class UUIDUtilTest {
 
   @Test
   void toBytes_異常系_nullを渡すとIllegalArgumentExceptionがスローされること() {
-    assertThatThrownBy(() -> UUIDUtil.toBytes(null))
+    assertThatThrownBy(() -> UUIDUtil.toBytes((UUID) null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("UUIDはnullにできません");
+  }
+
+  @Test
+  void toBytes_String_異常系_nullを渡すとIllegalArgumentExceptionがスローされること() {
+    assertThatThrownBy(() -> UUIDUtil.toBytes((String) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("uuidString must not be null");
   }
 
   @Nested

--- a/src/test/java/raisetech/student/management/util/UUIDUtilTest.java
+++ b/src/test/java/raisetech/student/management/util/UUIDUtilTest.java
@@ -1,0 +1,77 @@
+package raisetech.student.management.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link UUIDUtil} のユニットテスト。
+ *
+ * <p>UUID と byte[16] の相互変換ロジックについて、
+ * 正常系／異常系をシンプルに検証します。
+ */
+public class UUIDUtilTest {
+
+  // テスト共通で使う固定 UUID（再現性のために固定値を1つ用意）
+  private static final UUID FIXED_UUID =
+      java.util.UUID.fromString("12345678-9abc-def0-1234-56789abcdef0");
+
+  @Nested
+  class FromUUIDTest {
+
+    @Test
+    void fromUUID_正常系_16バイト配列に変換できること() {
+      byte[] bytes = UUIDUtil.fromUUID(FIXED_UUID);
+
+      // 16バイトであること
+      assertThat(bytes)
+          .isNotNull()
+          .hasSize(16);
+
+      // 往復させると同じ UUID に戻ること
+      UUID restored = UUIDUtil.toUUID(bytes);
+      assertThat(restored).isEqualTo(FIXED_UUID);
+    }
+  }
+
+  @Test
+  void fromUUID_異常系_nullを渡すとIllegalArgumentExceptionがスローされること() {
+    assertThatThrownBy(() -> UUIDUtil.fromUUID(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("UUIDはnullにできません");
+  }
+
+  @Nested
+  class ToUUIDTest {
+
+    @Test
+    void toUUID_正常系_16バイト配列からUUIDに復元できること() {
+      // まず fromUUID で 16バイト配列を作る
+      byte[] bytes = UUIDUtil.fromUUID(FIXED_UUID);
+
+      UUID result = UUIDUtil.toUUID(bytes);
+
+      assertThat(result).isEqualTo(FIXED_UUID);
+    }
+
+    @Test
+    void toUUID_異常系_nullを渡すとIllegalArgumentExceptionがスローされること() {
+      assertThatThrownBy(() -> UUIDUtil.toUUID(null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("UUIDの形式が不正です");
+    }
+
+    @Test
+    void toUUID_異常系_16バイト以外の配列を渡すとIllegalArgumentExceptionがスローされること() {
+      byte[] invalid = new byte[4];
+
+      assertThatThrownBy(() -> UUIDUtil.toUUID(invalid))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("UUIDの形式が不正です");
+    }
+  }
+}
+

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,12 +1,16 @@
 # ==============================
 # H2 Database (MyBatis Test)
 # ==============================
-spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+# application-test.properties(for Test)
+# spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+# application-local.properties(for Local Development)
+spring.datasource.url=jdbc:h2:~/test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
-spring.datasource.password=
+spring.datasource.password=sa
 spring.mvc.converters.preferred-json-mapper=jackson
-
+spring.sql.init.mode=always
+spring.h2.console.enabled=true
 # ==============================
 # MyBatis
 # ==============================

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,18 +1,22 @@
+# application-test.properties(for Test)
 # ==============================
 # H2 Database (MyBatis Test)
 # ==============================
-# application-test.properties(for Test)
-# spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-# application-local.properties(for Local Development)
-spring.datasource.url=jdbc:h2:~/test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+# Usernames and passwords are effectively unnecessary in tests,
+# but we explicitly set them for clarity.
 spring.datasource.username=sa
 spring.datasource.password=sa
 spring.mvc.converters.preferred-json-mapper=jackson
+# Run schema.sql and data.sql on every test run.
 spring.sql.init.mode=always
-spring.h2.console.enabled=true
+# H2 console is not needed for tests, so we don?t configure it here.
+# (Default is disabled.)
+# spring.h2.console.enabled=false
 # ==============================
 # MyBatis
 # ==============================
 mybatis.mapper-locations=classpath*:mapper/*.xml
 mybatis.configuration.map-underscore-to-camel-case=true
+

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -17,6 +17,7 @@ spring.sql.init.mode=always
 # ==============================
 # MyBatis
 # ==============================
-mybatis.mapper-locations=classpath*:mapper/*.xml
+mybatis.mapper-locations=classpath*:mappers/**/*.xml
 mybatis.configuration.map-underscore-to-camel-case=true
-
+logging.level.org.mybatis=DEBUG
+logging.level.org.apache.ibatis=DEBUG

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,0 +1,364 @@
+INSERT INTO students (
+  student_id, full_name, furigana, nickname,
+  email, location, age, gender, remarks,
+  is_deleted, deleted_at
+) VALUES
+(
+  X'19D8186DB15E454E80EF4C8F4D550DD8',
+  'Yamada Taro',
+  'やまだ　たろう',
+  'タロウ',
+  'taro.yamada@example.com',
+  'Osaka',
+  35,
+  'Male',
+  'コース追加予定',
+  0,
+  NULL
+),
+(
+  X'5A7441B8733A42898216CE772AC42B23',
+  'Kwon Youngdon',
+  'クォン・ヨンドン',
+  'ドニー',
+  'dony@example.com',
+  '韓国',
+  35,
+  'Male',
+  NULL,
+  0,
+  NULL
+),
+(
+  X'71DF1C030775400D92B3B03EF4DE460F',
+  'Kwon Youngdeuk',
+  'クォン・ヨンドゥク',
+  'ドゥキ',
+  'deuki@example.com',
+  '韓国',
+  35,
+  'Male',
+  NULL,
+  0,
+  NULL
+),
+(
+  X'74D5CC4EF9B411EF800D77A6DA541670',
+  'Kim Jisoo',
+  'キム ジス',
+  'ジス',
+  'jisoo@example.com',
+  'Saitama',
+  30,
+  'Female',
+  NULL,
+  0,
+  NULL
+),
+(
+  X'74D64AB6F9B411EF800D77A6DA541670',
+  'Kim Jennie',
+  'キム ジェニ',
+  'ジェニー',
+  'jennie@example.com',
+  'Kanagawa',
+  29,
+  'Female',
+  NULL,
+  0,
+  NULL
+),
+(
+  X'74D64D90F9B411EF800D77A6DA541670',
+  'Park Chaeyoung',
+  'パク チェヨン',
+  'ロゼ',
+  'rose@example.com',
+  'Australia',
+  28,
+  'Female',
+  NULL,
+  0,
+  NULL
+),
+(
+  X'74D64EE4F9B411EF800D77A6DA541670',
+  'Lalisa Manobal',
+  'ラリサ マノバン',
+  'リサ',
+  'lisa@example.com',
+  'Thailand',
+  27,
+  'Female',
+  NULL,
+  0,
+  NULL
+),
+(
+  X'839A5C6F3ACC45F3B92A46273A683215',
+  'Park Hong-jun',
+  'パク　ホンジュン',
+  'テディ',
+  'teddy@example.com',
+  'ニューヨーク',
+  46,
+  'Male',
+  NULL,
+  0,
+  NULL
+),
+(
+  X'880C6AACF26111EF8A56CABD577D6BA1',
+  'Choi Seunghyun',
+  'チェ スンヒョン',
+  'タプ',
+  'top@example.com',
+  'Hokkaido',
+  37,
+  'Male',
+  NULL,
+  0,
+  NULL
+),
+(
+  X'880CE32EF26111EF8A56CABD577D6BA1',
+  'Dong Youngbae',
+  'トン ヨンベ',
+  'テヤン',
+  'sol@example.com',
+  'Tokyo',
+  36,
+  'Male',
+  NULL,
+  0,
+  NULL
+),
+(
+  X'880CE6C6F26111EF8A56CABD577D6BA1',
+  'Kwon Jiyong',
+  'クォン ジヨン',
+  'ジヨン',
+  'gd@example.com',
+  'Nagoya',
+  36,
+  'Non-binary',
+  NULL,
+  0,
+  NULL
+),
+(
+  X'880CE838F26111EF8A56CABD577D6BA1',
+  'Kang Daesung',
+  'カン デソン',
+  'デソン',
+  'dlite@example.com',
+  'Fukuoka',
+  35,
+  'Male',
+  NULL,
+  0,
+  NULL
+),
+(
+  X'880CF58AF26111EF8A56CABD577D6BA1',
+  'Lee Seunghyun',
+  'イ　スンヒョン',
+  'スンリ',
+  'vi@example.com',
+  'Osaka',
+  34,
+  'Male',
+  NULL,
+  0,
+  NULL
+),
+(
+  X'8947FF9B034F46FF9C5F83AB1833A8FD',
+  'Choi Dong Wook',
+  'チェ　ドンウク',
+  'セブン',
+  'se7en@example.com',
+  '韓国',
+  40,
+  'Male',
+  NULL,
+  1,
+  '2025-04-20 20:31:51'
+),
+(
+  X'D918FB5CFB4111EF8C1BE0591C80306E',
+  'Yang Hyun-suk',
+  'ヤン　ヒョンソク',
+  'ヤンサ',
+  'yang@example.com',
+  'Chiba',
+  55,
+  'Male',
+  NULL,
+  1,
+  '2025-04-20 20:30:42'
+),
+(
+  X'DADAF78FC8C94725A0A6ED3BF31DD215',
+  'Lee Bada',
+  'イ　バダ',
+  'バダ　リー',
+  'bada@example.com',
+  '韓国',
+  29,
+  'Female',
+  NULL,
+  0,
+  NULL
+);
+
+INSERT INTO student_courses (
+  course_id, student_id, course_name, start_date, end_date
+) VALUES
+(
+  X'129E7E3CFED84173A5D0F62D589CC5E7',
+  X'839A5C6F3ACC45F3B92A46273A683215',
+  'デザインコース',
+  DATE '2025-03-01',
+  NULL
+),
+(
+  X'1ADDAF706FEB460EA488C3DCD2D314CB',
+  X'71DF1C030775400D92B3B03EF4DE460F',
+  'デザインコース',
+  DATE '2025-03-01',
+  NULL
+),
+(
+  X'22A76F780EC7423EBC35EE924EE82A0F',
+  X'DADAF78FC8C94725A0A6ED3BF31DD215',
+  'デザインコース',
+  DATE '2025-03-01',
+  NULL
+),
+(
+  X'24619A3DBCD846E7826D4CFE067F6BAF',
+  X'8947FF9B034F46FF9C5F83AB1833A8FD',
+  'Javaコース',
+  DATE '2024-04-01',
+  DATE '2025-03-31'
+),
+(
+  X'2A6E57D6F27311EF8A56CABD577D6BA1',
+  X'880C6AACF26111EF8A56CABD577D6BA1',
+  'Javaコース',
+  DATE '2022-04-01',
+  DATE '2023-05-31'
+),
+(
+  X'2A6EF128F27311EF8A56CABD577D6BA1',
+  X'880CE32EF26111EF8A56CABD577D6BA1',
+  'AWSコース',
+  DATE '2024-04-01',
+  NULL
+),
+(
+  X'2A6EF4CAF27311EF8A56CABD577D6BA1',
+  X'880CE32EF26111EF8A56CABD577D6BA1',
+  'Javaコース',
+  DATE '2023-04-01',
+  DATE '2024-03-31'
+),
+(
+  X'2A6EF664F27311EF8A56CABD577D6BA1',
+  X'880CE6C6F26111EF8A56CABD577D6BA1',
+  '映像制作コース',
+  DATE '2024-04-01',
+  NULL
+),
+(
+  X'2A6F105EF27311EF8A56CABD577D6BA1',
+  X'880CE6C6F26111EF8A56CABD577D6BA1',
+  'デザインコース',
+  DATE '2023-04-01',
+  DATE '2024-03-31'
+),
+(
+  X'2A6F12FCF27311EF8A56CABD577D6BA1',
+  X'880CE838F26111EF8A56CABD577D6BA1',
+  '英会話コース',
+  DATE '2023-04-01',
+  NULL
+),
+(
+  X'2A6F1432F27311EF8A56CABD577D6BA1',
+  X'880CE838F26111EF8A56CABD577D6BA1',
+  'WordPress副業コース',
+  DATE '2022-04-01',
+  DATE '2023-03-31'
+),
+(
+  X'2A6F1554F27311EF8A56CABD577D6BA1',
+  X'880CF58AF26111EF8A56CABD577D6BA1',
+  'Webマーケティングコース',
+  DATE '2022-04-01',
+  DATE '2023-03-13'
+),
+(
+  X'50AFE6D2140A4FFBAF147022E5550478',
+  X'8947FF9B034F46FF9C5F83AB1833A8FD',
+  'AWSコース',
+  DATE '2025-04-01',
+  NULL
+),
+(
+  X'5A837B973D3D4043B16EF61533C685FA',
+  X'19D8186DB15E454E80EF4C8F4D550DD8',
+  'Javaコース',
+  DATE '2024-04-01',
+  DATE '2025-03-31'
+),
+(
+  X'7F0D1D00F9B611EF800D77A6DA541670',
+  X'74D64AB6F9B411EF800D77A6DA541670',
+  'Webマーケティングコース',
+  DATE '2022-04-01',
+  NULL
+),
+(
+  X'7F0D1F80F9B611EF800D77A6DA541670',
+  X'74D64D90F9B411EF800D77A6DA541670',
+  'フロントエンドコース',
+  DATE '2023-04-01',
+  NULL
+),
+(
+  X'7F0D216AF9B611EF800D77A6DA541670',
+  X'74D64EE4F9B411EF800D77A6DA541670',
+  'フロントエンドコース',
+  DATE '2023-04-01',
+  NULL
+),
+(
+  X'90153DDC1C2D11F0B106EBAA90D475CF',
+  X'D918FB5CFB4111EF8C1BE0591C80306E',
+  'Webマーケティングコース',
+  DATE '2016-04-01',
+  DATE '2019-05-31'
+),
+(
+  X'9A80B054DE464C51B4034FDF68766211',
+  X'5A7441B8733A42898216CE772AC42B23',
+  '映像制作コース',
+  DATE '2025-04-01',
+  NULL
+),
+(
+  X'9DC02CD6C5024DDCBB12CE64B6EF506A',
+  X'74D5CC4EF9B411EF800D77A6DA541670',
+  '映像制作コース',
+  DATE '2024-04-01',
+  NULL
+),
+(
+  X'D55DE78B7FFD498393BBC9B2430C6270',
+  X'19D8186DB15E454E80EF4C8F4D550DD8',
+  'フロントエンドコース',
+  DATE '2025-06-01',
+  NULL
+);

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS students(
+    student_id BINARY(16) NOT NULL,
+      full_name  VARCHAR(100) NOT NULL,
+      furigana   VARCHAR(100) NOT NULL,
+      nickname   VARCHAR(50),
+      email      VARCHAR(255) NOT NULL,
+      location   VARCHAR(100),
+      age        INT,
+      gender     VARCHAR(20) NOT NULL,
+      remarks    TEXT,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      deleted_at DATETIME,
+      is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+      CONSTRAINT pk_students PRIMARY KEY (student_id),
+      CONSTRAINT uq_students_email UNIQUE (email),
+      CONSTRAINT students_chk_1 CHECK (age >= 0)
+    );
+
+CREATE TABLE IF NOT EXISTS student_courses (
+  course_id    BINARY(16)    NOT NULL,
+  student_id   BINARY(16),
+  course_name  VARCHAR(255)  NOT NULL,
+  start_date   DATE          NOT NULL,
+  end_date     DATE,
+  created_at   TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT pk_student_courses PRIMARY KEY (course_id),
+  CONSTRAINT idx_student_courses_student_id FOREIGN KEY (student_id)
+    REFERENCES students(student_id)
+);


### PR DESCRIPTION
## 概要

`students` / `student_courses` テーブルを対象とした Repository 層のテストと、
UUID ⇔ byte[16] 変換ユーティリティのテストを追加しました。

- StudentRepositoryTest
- StudentCourseRepositoryTest
- UUIDUtilTest

を中心に、テストデータ生成用の共通ヘルパーを導入して重複コードも整理しています。

---

## 追記（2025/12/16）
レビュアーご指摘の件、以下対応しました（コミットを分けて反映しています）。

- mybatis.mapper-locations を実配置（`src/main/resources/mappers`）に合わせて test/prod ともに統一（`classpath*:mappers/**/*.xml`）  
  - [7e245a8](https://github.com/picocico/StudentManagement/pull/23/commits/7e245a80fcd40f2693dbc5063361c35c160e53a0)
- Mapper XML から `byte[]` / `ByteArrayTypeHandler` の残骸を除去し、UUID前提で整合性を統一（parameterType/コメント含む）  
  - [e3095dc](https://github.com/picocico/StudentManagement/pull/23/commits/e3095dc82bdade23755fbbc762a20287c8e4431b)
- `findAllCourses` は `src/main/resources/mappers/StudentCourseRepository.xml` 内で定義が1件であることを確認（重複なし）
- Swagger/JavaDoc の説明文を uuid 表記に整理  
  - [5afd9db](https://github.com/picocico/StudentManagement/pull/23/commits/5afd9db4c8680fde6b584d37da7c43cb1d93a086)

また、ローカルで以下を実行し、クリーン環境でも起動・テストが通ることを確認しました。  
`./gradlew clean test`  
`./gradlew clean bootRun`

さらに、CI（GitHub Actions）もグリーンであることを確認済みです。

---
## 追記（2025/12/13）
[8ebfce7](https://github.com/picocico/StudentManagement/pull/23/commits/8ebfce7dcfa2f2f1cdf6ed1dc21494339f35386f)

今回のレビューコメントおよび設計見直しを踏まえ、以下の対応を追加しました。

- ドメイン／サービス／コントローラ層で扱う ID 型を `byte[]` から `UUID` へ統一
  - `Student` / `StudentCourse` エンティティ
  - `StudentService` / `StudentServiceImpl`
  - `StudentController` / `AdminStudentController`
  - `StudentConverter` および関連テスト（`StudentConverterTest`, `StudentServiceImplTest`, `StudentController*Test`）
- 管理者用物理削除 API 向けに `AdminStudentControllerTest` を追加
  - 正常系（204）／UUID形式不正（400）／対象なし（404）のパターンをカバー
- `application-test.properties` をインメモリ H2 利用の構成に変更
  - `spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE`
  - `spring.sql.init.mode=always` を指定し、テスト実行ごとに `schema.sql` / `data.sql` が必ず適用されるように修正
- 初期データ変更時の運用方針を明文化  
  - `schema.sql` / `data.sql` の初期データに依存しているテストについては、  
    **初期データを変更する際に、必ず対応するテストの期待件数・期待値もあわせて更新する**  
    方針でコメントを追記しました（`application-test.properties` およびテストクラス内コメント）。

---

## 追記（2025/11/28)
[36662d7](https://github.com/picocico/StudentManagement/pull/23/commits/36662d7af0ace9ec9e1b0a6b46f4b8afdb602792)

-「main を取り込み、UUIDUtil / StudentIdCodecTest のコンフリクトを解消しました」
-「ローカル ./gradlew clean test 通過しました」

---

## 変更内容
[803cb71](https://github.com/picocico/StudentManagement/pull/23/commits/803cb7164d2a1040f071704d88210fc3e02c0f49)

### 1. StudentRepositoryTest の追加・拡充

- `searchStudents` のパターンを網羅
  - 全件取得（論理削除を含む）
  - 論理削除除外
  - 論理削除のみ
  - ふりがなによる部分一致検索
- `insertStudent`
  - INSERT 前後で件数が +1 されることを確認
  - 追加した `student_id` を持つレコードが存在することを確認
- `findById`
  - 既存 ID で取得できること
  - 存在しない ID の場合は `null` が返ること
- `updateStudent`
  - 正常に更新できること（名前・ふりがな・備考の変更）
  - `full_name` を `null` にした場合に NOT NULL 制約違反になること
  - 存在しない ID を指定した場合に 0 件更新となること
  - メールアドレス重複時にユニーク制約違反 (`DataIntegrityViolationException`) となること
  - 年齢が負数の場合に `DataIntegrityViolationException` となること
- `forceDeleteStudent`
  - 既存受講生が物理削除されること
  - 存在しない ID の場合は 0 件削除となること
  - 紐づく受講コースが残っている場合に FK 制約違反となること

テストデータ生成用に以下のヘルパーを導入し、テスト内の重複コードを削減しました。

- `insertStudent(...)`
- `insertTestStudentAndReturnId()`
- `insertTestStudentAndReturnId(String email)`

---

### 2. StudentCourseRepositoryTest の追加・拡充

- `findAllCourses`
  - 初期データとして 21 件取得できることを確認
- `findCoursesByStudentId`
  - 複数受講生・複数コースを登録し、特定受講生 ID に紐づくコースのみ取得されること
- `insertCourses`
  - 同一受講生に対する複数コースの一括登録が行えること
- `insertCourses`（異常系）
  - `students` テーブルに存在しない `student_id` を指定した場合に FK 制約違反となること
- `insertIfNotExists`
  - 存在しない `(student_id, course_name)` の組み合わせなら 1 件登録されること
  - 同一 `(student_id, course_name)` を 2 回呼び出しても 1 件しか登録されないこと
- `deleteCoursesByStudentId`
  - 指定受講生 ID に紐づくコースが全て削除されること
  - コースが存在しない ID を指定しても例外が発生しないこと

テストでは以下のヘルパーを導入して、日付や ID のセットアップを簡潔化しています。

- `insertTestStudentAndReturnId()`  
  - FK 制約を満たすための受講生レコードを students テーブルに登録
- `newCourse(byte[] studentId, String courseName, LocalDate start, LocalDate end)`  
- `newCourse(byte[] studentId, String courseName)`  
  - デフォルト期間付きで `StudentCourse` を組み立てるためのショートカット

---

### 3. UUIDUtilTest の追加

`UUIDUtil` の基本的な変換ロジックについて、正常系／異常系をテストしています。

- `toBytes`
  - 固定 UUID から 16 バイト配列に変換できること
  - 変換した配列を `toUUID` に戻すと元の UUID と一致すること（往復変換の確認）
  - `null` を渡すと `IllegalArgumentException` がスローされること
- `fromBytes`
  - 16 バイト配列から UUID に復元できること
  - `null` を渡した場合に `IllegalArgumentException` がスローされること
  - 長さ 16 以外の配列を渡した場合に `IllegalArgumentException` がスローされること

---

## テスト

- `./gradlew clean test` を実行し、すべてのテストが成功することを確認済みです。
  - StudentRepositoryTest
  - StudentCourseRepositoryTest
  - StudentIdCodecTest（既存）
  - UUIDUtilTest
  - StudentConverterTest
  - StudentServiceImplTest
  - StudentController*Test
  - AdminStudentControllerTest

---

## 補足

  - `data.sql` の初期データに依存しているテストについては、想定件数（例: students 16 件、student_courses 21 件）を前提としています。
  - 初期データを変更する場合は、該当テストの期待件数・期待値も合わせて更新する運用としました（コメントとしても明記済みです）。
  - なお、従来利用していた `ByteArrayTypeHandler` は、現在の Mapper からは参照されておらず、UUID 専用の TypeHandler（およびそのテスト）に一本化しています。